### PR TITLE
Add partial failure support for Google Ads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ generate_csv.sh
 .idea
 .venv
 .vscode
+my_serv_acc.json

--- a/megalist_dataflow/uploaders/utils.py
+++ b/megalist_dataflow/uploaders/utils.py
@@ -34,6 +34,7 @@ def get_ads_service(service_name, version, oauth_credentials, developer_token,
         oauth2_client,
         'MegaList Dataflow',
         client_customer_id=customer_id)
+    client.partial_failure = True
     return client.GetService(service_name, version=version)
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,7 +17,7 @@ locals {
         "jobName": "megalist_daily",
         "parameters": {
             "developer_token": "${var.developer_token}",
-            "client_id": "${var.client_id},
+            "client_id": "${var.client_id}",
             "client_secret": "${var.client_secret}",
             "access_token": "${var.access_token}",
             "refresh_token": "${var.refresh_token}",


### PR DESCRIPTION
Hi, we've added support for partial failures in Google Ads conversion uploads. By default, if a single row contains errors, the entire batch is blocked. This change aims to allow any valid rows to be uploaded, regardless of errors in other rows in the same batch. For more information: https://developers.google.com/adwords/api/docs/guides/partial-failure

Topics for future consideration:
1. We could make this optional, if needed.
2. Megalist currently shows only the amount of rows that reached the uploader. We intend to contribute again soon with changes that display the number of rows that were, in fact, accepted by the API, as well as logs that register invalid rows individually and the reason for their rejections.