### PR TITLE
Added JSON configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Sample integration code for onboarding offline/CRM data from BigQuery as custom 
 ## How does it work
 Megalista was design to separate the configuration of conversion/audience upload rules from the engine, giving more freedom for non-technical teams (i.e. Media and Business Inteligence) to setup multiple upload rules on their own.
 
-The solution consists in #1 a Google Spreadsheet (template) in which all rules are defined by mapping a data source (BigQuery Table) to a destination (data upload endpoint) and #2, an apache beam workflow running on Google Dataflow, scheduled to upload the data in batch mode.
+The solution consists of #1 a configuration file (either Google Sheet or JSON file) in which all rules are defined by mapping a data source (BigQuery Table) to a destination (data upload endpoint) and #2, an Apache Beam workflow running on Google Dataflow, scheduled to upload the data in batch mode.
 
 ## Prerequisites
 
@@ -60,7 +60,7 @@ Those are the minimum roles necessary to deploy Megalista:
 
 ### APIs
 Required APIs will depend on upload endpoints in use. We recomend you to enable all of them:
-- Google Sheets (required for any use case) [[link]](https://console.cloud.google.com/apis/library/sheets.googleapis.com)
+- Google Sheets (required if using Sheets configuration) [[link]](https://console.cloud.google.com/apis/library/sheets.googleapis.com)
 - Google Analytics [[link]](https://console.cloud.google.com/apis/library/analytics.googleapis.com)
 - Google Analytics Reporting [[link]](https://console.cloud.google.com/apis/library/analyticsreporting.googleapis.com)
 - Google Ads [[link]](https://console.cloud.google.com/apis/library/googleads.googleapis.com)
@@ -69,8 +69,25 @@ Required APIs will depend on upload endpoints in use. We recomend you to enable 
 
 ## Installation
 
-### Create a copy of the configuration Spreadsheet
-WIP
+### Configure Megalista
+Megalista can be configured via either Google Sheets or a JSON file. Expected data schemas (Sources) and metadata (Destinations) for each use case defined in [the Megalista Wiki](https://github.com/google/megalista/wiki).
+
+To configure using Google Sheets:
+ - Make a copy of the [Sheets template](https://docs.google.com/spreadsheets/d/1rP9x93h5CVu2IdUjP6yJ8yYEMcb9J_WPx2sBEEpLMJI)
+ - In the "Intro" sheet provide Account IDs for Google Ads, Analytics, CM360, etc.
+ - Configure source/input data in the "Sources" sheet
+ - Configure destinations in the "Destinations" sheet
+  + The "Help" sheet has a chart to document the required metadata for each use case.
+ - Configure connections from Sources to Destinations in the "Connect" sheet
+ - Make note of the Sheet's ID in the URL: `docs.google.com/spreadsheets/d/`**EXAMPLEIDHERE**`/edit`
+
+ To configure using JSON:
+ - Make a copy of the [JSON template](https://github.com/google/megalista/tree/main/cloud_config/configuration_sample.json)
+ - Provide Account IDs for Google Ads, Analytics, CM360, etc.
+ - Configure Sources and Destinations, separating entries with commas
+ - Connect Sources to Destinations in the "Connections" field
+ - Save and upload this JSON file to a Google Cloud Storage bucket (default bucket options are fine)
+ - Make note of the files's Authenticated URL in the Cloud Storage UI: `storage.cloud.google.com/`**mybucketname/myconfig.json**
 
 ### Creating required access tokens
 To access campaigns and user lists on Google's platforms, this dataflow will need OAuth tokens for a account that can authenticate in those systems.
@@ -90,17 +107,19 @@ This bucket will hold the deployed code for this solution. To create it, navigat
 
 ## Running Megalista
 
-We recommend first running it locally and make sure that everything works. 
+We recommend first running it locally and make sure that everything works.
 Make some sample tables on BigQuery for one of the uploaders and make sure that the data is getting correctly to the destination.
 After that is done, upload the Dataflow template to GCP and try running it manually via the UI to make sure it works.
 Lastly, configure the Cloud Scheduler to run Megalista in the frequency desired and you'll have a fully functional data integration pipeline.
 
 ### Running locally
+Only set one configuration parameter (either setup_sheet_id or setup_json_url)
 ```bash
 python3 megalist_dataflow/main.py \
   --runner DirectRunner \
   --developer_token ${GOOGLE_ADS_DEVELOPER_TOKEN} \
   --setup_sheet_id ${CONFIGURATION_SHEET_ID} \
+  --setup_json_url ${CONFIGURATION_JSON_URL} \
   --refresh_token ${REFRESH_TOKEN} \
   --access_token ${ACCESS_TOKEN} \
   --client_id ${CLIENT_ID} \
@@ -111,27 +130,24 @@ python3 megalist_dataflow/main.py \
 ```
 
 ### Deploying Pipeline
-To deploy, use the following commands from the root folder:
-```
-cd terraform
-./scripts/deploy_cloud.sh project_id bucket_name region_name
-```
+To deploy the full Megalista pipeline, use the following command from the root folder:
+`./terraform_deploy.sh`
 
 #### Manually executing pipeline using Dataflow UI
-To execute the pipeline, use the following steps: 
+To execute the pipeline, use the following steps:
 - Go to **Dataflow** on GCP console
 - Click on *Create job from template*
-- On the template selection dropdown, select *Custom template* 
+- On the template selection dropdown, select *Custom template*
 - Find the *megalist* file on the bucket you've created, on the templates folder
 - Fill in the parameters required and execute
 
 ### Scheduling pipeline
 To schedule daily/hourly runs, go to **Cloud Scheduler**:
-- Click on *create job* 
+- Click on *create job*
 - Add a name and frequency as desired
 - For *target* set as HTTP
 - Configure a *POST* for url: https://dataflow.googleapis.com/v1b3/projects/${YOUR_PROJECT_ID}/locations/${LOCATION}/templates:launch?gcsPath=gs://${BUCKET_NAME}/templates/megalist, replacing the params with the actual values
-- For a sample on the *body* of the request, check **cloud_config/scheduler.json**
+- For a sample on the *body* of the request, check **cloud_config/scheduler_sample.json**
 - Add OAuth Headers
 - Scope: https://www.googleapis.com/auth/cloud-platform
 

--- a/cloud_config/configuration_sample.json
+++ b/cloud_config/configuration_sample.json
@@ -1,0 +1,45 @@
+{
+  "GoogleAdsAccountId": "",
+  "GoogleAdsMCC": false,
+  "AppId": "",
+  "GoogleAnalyticsAccountId": "",
+  "CampaignManagerAccountId": "",
+  "Sources": [
+    {
+      "Name": "example Ads offline conversions source",
+      "Type": "BIG_QUERY",
+      "Dataset": "my_source_dataset",
+      "Table": "my_offline_conversions_table"
+    },
+    {
+      "Name": "example measurement protocol source",
+      "Type": "BIG_QUERY",
+      "Dataset": "my_source_dataset",
+      "Table": "my_analytics_table"
+    }
+  ],
+  "Destinations": [
+    {
+      "Name": "example Ads offline conversions destination",
+      "Type": "ADS_OFFLINE_CONVERSION",
+      "Metadata": ["Ads_Conversion_Name"]
+    },
+    {
+      "Name": "example measurement protocol destination",
+      "Type": "GA_MEASUREMENT_PROTOCOL",
+      "Metadata": ["GA_Property_ID", 1]
+    }
+  ],
+  "Connections": [
+    {
+      "Enabled": true,
+      "Source": "example Ads offline conversions source",
+      "Destination": "example Ads offline conversions destination"
+    },
+    {
+      "Enabled": true,
+      "Source": "example measurement protocol source",
+      "Destination": "example measurement protocol destination"
+    }
+  ]
+}

--- a/cloud_config/scheduler_sample.json
+++ b/cloud_config/scheduler_sample.json
@@ -6,7 +6,8 @@
         "client_secret": "GCP OAuth Client Secret",
         "access_token": "GCP OAuth access token",
         "refresh_token": "GCP OAuth refresh token",
-        "setup_sheet_id": "Setup Google Sheets Id",
+        "setup_sheet_id": "Setup Google Sheets Id (not needed for JSON config)",
+        "setup_json_url": "Setup JSON URL (not needed for Sheets config)",
         "bq_ops_dataset": "Auxliary bigquery dataset used for Megalista operations",
 	"appsflyer_dev_key": "Apps flyer dev key"
     },

--- a/megalist_dataflow/megalist_metadata
+++ b/megalist_dataflow/megalist_metadata
@@ -34,6 +34,11 @@
             "help_text": "Google Sheets id for config"
         },
         {
+            "name": "setup_json_url",
+            "label": "URL for JSON config file",
+            "help_text": "URL for JSON config file"
+        },
+        {
             "name": "bq_ops_dataset",
             "label": "Auxliary bigquery dataset used for Megalista operations",
             "help_text": "Auxliary bigquery dataset used for Megalista operations"

--- a/megalist_dataflow/models/json_config.py
+++ b/megalist_dataflow/models/json_config.py
@@ -1,0 +1,33 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from google.cloud import storage
+
+
+class JsonConfig:
+
+  def parse_json_from_url(self, url):
+    url = url.replace("https://", "")
+    url_components = url.split("/", 2)
+    bucket_name, file_path = url_components[1], url_components[2]
+    bucket = storage.Client().get_bucket(bucket_name)
+    blob = bucket.blob(file_path)
+    data = json.loads(blob.download_as_string())
+    return data
+
+  def get_value(self, config_json, key):
+    if key not in config_json or not config_json[key]:
+      return None
+    return config_json[key]

--- a/megalist_dataflow/models/options.py
+++ b/megalist_dataflow/models/options.py
@@ -30,7 +30,11 @@ class DataflowOptions(PipelineOptions):
         '--access_token', help='OAUTH Access Token for the Google APIs')
     # Set up
     parser.add_value_provider_argument(
-        '--setup_sheet_id', help='Id of Spreadsheet with execution info')
+        '--setup_sheet_id',
+        help='Id of Spreadsheet with execution info (don\'t set if using JSON)')
+    parser.add_value_provider_argument(
+        '--setup_json_url',
+        help='URL of JSON file with execution info (don\'t set if using Sheet)')
     parser.add_value_provider_argument(
         '--bq_ops_dataset',
         help='Auxliary bigquery dataset used for Megalista operations')

--- a/megalist_dataflow/requirements.txt
+++ b/megalist_dataflow/requirements.txt
@@ -19,3 +19,4 @@ aiohttp==3.6.2
 bloom-filter==1.3
 six==1.13.0
 mypy==0.790
+google-cloud-storage==1.38.0

--- a/megalist_dataflow/sources/json_execution_source.py
+++ b/megalist_dataflow/sources/json_execution_source.py
@@ -1,0 +1,94 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from apache_beam.options.value_provider import ValueProvider
+
+from sources.base_bounded_source import BaseBoundedSource
+from models.execution import Destination, DestinationType
+from models.execution import Execution, AccountConfig
+from models.execution import Source, SourceType
+from models.json_config import JsonConfig
+
+
+class JsonExecutionSource(BaseBoundedSource):
+  """
+  Read Execution data from a JSON file. The URL is set-up in the parameter "setup_json_url"
+  """
+
+  def __init__(self, json_config: JsonConfig, setup_json_url: ValueProvider):
+    super().__init__()
+    self._json_config = json_config
+    self._setup_json_url = setup_json_url
+
+  def _do_count(self):
+    json_url = self._setup_json_url.get()
+    json_data = self._json_config.parse_json_from_url(json_url)
+    return len(json_data)
+
+  def read(self, range_tracker):
+    json_url = self._setup_json_url.get()
+    logging.getLogger("megalista.JsonExecutionSource").info(f"Loading configuration JSON {json_url}...")
+
+    json_data = self._json_config.parse_json_from_url(json_url)
+    google_ads_id = self._json_config.get_value(json_data, "GoogleAdsAccountId")
+    mcc_json = self._json_config.get_value(json_data, "GoogleAdsMCC")
+    mcc = False if mcc_json is None else mcc_json
+    app_id = self._json_config.get_value(json_data, "AppId")
+    google_analytics_account_id = self._json_config.get_value(json_data, "GoogleAnalyticsAccountId")
+    campaign_manager_account_id = self._json_config.get_value(json_data, "CampaignManagerAccountId")
+    account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_account_id, app_id)
+    logging.getLogger("megalista.JsonExecutionSource").info(f"Loaded: {account_config}")
+
+    sources = self._read_sources(self._json_config, json_data)
+    destinations = self._read_destination(self._json_config, json_data)
+
+    schedules = self._json_config.get_value(json_data, "Connections")
+    if schedules:
+      for schedule in schedules:
+        if schedule["Enabled"]:
+          logging.getLogger("megalista.JsonExecutionSource").info(
+            f"Executing step Source:{schedule['Source']} -> Destination:{schedule['Destination']}")
+          yield Execution(account_config, sources[schedule["Source"]], destinations[schedule["Destination"]])
+    else:
+      logging.getLogger("megalista.JsonExecutionSource").warn("No schedules found!")
+
+  @staticmethod
+  def _read_sources(json_config, json_data):
+    sources_list = json_config.get_value(json_data, "Sources")
+    sources = {}
+    if sources_list:
+      for row in sources_list:
+        # Create Sources using Name, Type, and Metadata (dataset, table)
+        source = Source(row["Name"], SourceType[row["Type"]],
+                        [row["Dataset"], row["Table"]])
+        sources[source.source_name] = source
+    else:
+      logging.getLogger("megalista.JsonExecutionSource").warn("No sources found!")
+    return sources
+
+  @staticmethod
+  def _read_destination(json_config, json_data):
+    destinations_list = json_config.get_value(json_data, "Destinations")
+    destinations = {}
+    if destinations_list:
+      for row in destinations_list:
+        # Create Destinations using Name, Type, and Metadata
+        destination = Destination(row["Name"], DestinationType[row["Type"]],
+                                  row["Metadata"])
+        destinations[destination.destination_name] = destination
+    else:
+      logging.getLogger("megalista.JsonExecutionSource").warn("No destinations found!")
+    return destinations

--- a/megalist_dataflow/sources/primary_execution_source.py
+++ b/megalist_dataflow/sources/primary_execution_source.py
@@ -1,0 +1,62 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from apache_beam.options.value_provider import ValueProvider
+
+from sources.base_bounded_source import BaseBoundedSource
+from sources.spreadsheet_execution_source import SpreadsheetExecutionSource
+from sources.json_execution_source import JsonExecutionSource
+from models.execution import Destination, DestinationType
+from models.execution import Execution, AccountConfig
+from models.execution import Source, SourceType
+from models.json_config import JsonConfig
+from models.sheets_config import SheetsConfig
+
+
+class PrimaryExecutionSource(BaseBoundedSource):
+  """
+  Determines execution data based on provided JSON or Sheet information. Control
+  class needed since variables can't be accessed until runtime.
+  """
+
+  def __init__(self,
+        sheets_config: SheetsConfig,
+        json_config: JsonConfig,
+        setup_sheet_id: ValueProvider,
+        setup_json_url: ValueProvider):
+    super().__init__()
+    self._setup_sheet_id = setup_sheet_id
+    self._setup_json_url = setup_json_url
+    self._sheets_execution_source = SpreadsheetExecutionSource(sheets_config,
+                                                               setup_sheet_id)
+    self._json_execution_source = JsonExecutionSource(json_config,
+                                                      setup_json_url)
+
+  def _do_count(self):
+    if self._setup_sheet_id.get():
+      logging.getLogger("megalista").info("Using Sheets count")
+      return self._sheets_execution_source._do_count()
+    else:
+      logging.getLogger("megalista").info("Using JSON count")
+      return self._json_execution_source._do_count()
+
+  def read(self, range_tracker):
+    if self._setup_sheet_id.get():
+      logging.getLogger("megalista").info("Reading Sheets configuration")
+      return self._sheets_execution_source.read(range_tracker)
+    else:
+      logging.getLogger("megalista").info("Reading JSON configuration")
+      return self._json_execution_source.read(range_tracker)

--- a/terraform/external.tf
+++ b/terraform/external.tf
@@ -1,7 +1,7 @@
 #create detaflow metadata
 resource "null_resource" "bucket_megalista_metadata" {
   provisioner "local-exec" {
-    command = "sh ./scripts/deploy_cloud.sh ${data.google_client_config.current.project} ${var.bucket_name} ${var.region}"
+    command = "sh ./terraform/scripts/deploy_cloud.sh ${data.google_client_config.current.project} ${var.bucket_name} ${var.region}"
   }
 
   depends_on = [google_storage_bucket.my_storage]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,6 +11,10 @@ resource "google_bigquery_dataset" "dataset" {
   delete_contents_on_destroy = true
 }
 
+resource "null_resource" "only_one_configuration_provided" {
+  count = ("${var.setup_sheet_id}" != "" && "${var.setup_json_url}" != "") ? "Cannot provide both Sheet and JSON configs" : 0
+}
+
 locals {
     scheduler_body = <<EOF
     {
@@ -22,6 +26,7 @@ locals {
             "access_token": "${var.access_token}",
             "refresh_token": "${var.refresh_token}",
             "setup_sheet_id": "${var.setup_sheet_id}",
+            "setup_json_url": "${var.setup_json_url}",
             "bq_ops_dataset": "${var.bq_ops_dataset}",
         },
         "environment": {

--- a/terraform/scripts/deploy_cloud.sh
+++ b/terraform/scripts/deploy_cloud.sh
@@ -20,7 +20,6 @@ if [ $# != 3 ]; then
 fi
 
 echo "Move to megalist_dataflow folder"
-cd ..
 cd megalist_dataflow
 echo "Configuration GCP project in gcloud"
 gcloud config set project "$1"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -39,7 +39,12 @@ variable "refresh_token" {
 
 variable "setup_sheet_id" {
     type = string
-    description = "Setup Sheet Id"
+    description = "Setup Sheet Id (leave blank if using JSON)"
+}
+
+variable "setup_json_url" {
+    type = string
+    description = "URL for JSON configuration (leave blank if using Sheets)"
 }
 
 variable "location" {


### PR DESCRIPTION
Added JSON configuration support as an alternative to Google Sheets. JSON file must be uploaded to Google Cloud Storage, where GCP client libraries can easily access it during Megalista deployment.

Also updated documentation to include a more descriptive configuration/deployment process.

### Why this approach?
Many clients are unable to access Google Sheets due to firewalls and security policies. JSON files are commonly used, easy to read, and can be configured in any basic text editor. Google Cloud Storage is already a requirement for deploying Megalista and can be easily accessed via gcloud commands/client libraries, which makes accessing the file during deployment very simple.

### How to configure using JSON
See `cloud_config/configuration_sample.json` for an example configuration file. The format very closely matches the Sheets template. `README.md` includes deployment steps.

### Specifying configuration type
The `setup_json_url` parameter should be used to pass the JSON file's URL. Code implementation defaults to Sheets configuration if that parameter is provided in Dataflow, but Terraform deployment script's `only_one_configuration_provided` node **will fail** if both JSON and Sheets configs are provided.