### PR TITLE
Fixed error when saving the uploaded data to a BigQuery table

### DIFF
--- a/megalist_dataflow/uploaders/big_query/transactional_events_results_writer.py
+++ b/megalist_dataflow/uploaders/big_query/transactional_events_results_writer.py
@@ -40,7 +40,7 @@ class TransactionalEventsResultsWriter(beam.DoFn):
   def _do_process(self, batch: Batch, now):
     execution = batch.execution
 
-    table_name = self._bq_ops_dataset.get() + '.' + execution.source.source_metadata[1] + "_uploaded"
+    table_name = execution.source.source_metadata[0] + '.' + execution.source.source_metadata[1] + "_uploaded"
 
     rows = batch.elements
     client = self._get_bq_client()


### PR DESCRIPTION
The process fails to create a BigQuery table with the uploaded data:

```    
table_name = self._bq_ops_dataset.get() + '.' + execution.source.source_metadata[1] + "_uploaded"
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str' 
```


The approach as to change it to `execution.source.source_metadata[0]` instead of `self._bq_ops_dataset.get()`, which is returning None instead of the Dataset name.