### PR TITLE
Updates terraform init and apply call

### DIFF
--- a/terraform_deploy.sh
+++ b/terraform_deploy.sh
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-terraform init terraform/
-terraform apply -auto-approve terraform/
+terraform -chdir=terraform init 
+terraform -chdir=terraform apply -auto-approve


### PR DESCRIPTION
Passing a directory as a parameter was deprecated on Terraform v0.14 and currently fails from a cloud shell with the following error:

```
Too many command line arguments. Did you mean to use -chdir?
╷
│ Error: Failed to load "terraform/" as a plan file
│
│ The specified path is a directory, not a plan file. You can use the global -chdir flag to use this directory as the configuration root.
```

Updated implementation by using -chdir flag.

More context on: https://www.terraform.io/docs/cli/commands/init.html#passing-a-different-configuration-directory