### PR TITLE
Support multiple ads accounts on customer match

### DIFF
--- a/megalist_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
+++ b/megalist_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
@@ -17,7 +17,7 @@ from typing import Dict, Any, List
 
 import apache_beam as beam
 from uploaders import utils
-from models.execution import AccountConfig
+from models.execution import AccountConfig, Destination
 from models.execution import DestinationType
 from models.execution import Batch
 from models.oauth_credentials import OAuthCredentials
@@ -63,7 +63,6 @@ class GoogleAdsCustomerMatchAbstractUploaderDoFn(beam.DoFn):
       # Create list
       logging.getLogger(_DEFAULT_LOGGER).info(
         '%s list does not exist, creating...', list_name)
-      user_list_service = self._get_user_list_service(customer_id)
       request = {
         'customer_id': customer_id,
         'partial_failure': False,
@@ -121,6 +120,14 @@ class GoogleAdsCustomerMatchAbstractUploaderDoFn(beam.DoFn):
       raise ValueError('Missing destination information. Received {}'.format(
           str(destination)))
 
+  def _get_customer_id(self, account_config:AccountConfig, destination:Destination) -> str:
+    """
+      If the customer_id is present on the destination, returns it, otherwise defaults to the account_config info.
+    """
+    if len(destination.destination_metadata) >= 5 and len(destination.destination_metadata[4]) > 0:
+      return destination.destination_metadata[4].replace('-', '')
+    return account_config.google_ads_account_id.replace('-', '')
+
   @utils.safe_process(logger=logging.getLogger(_DEFAULT_LOGGER))
   def process(self, batch: Batch, **kwargs) -> None:
     if not self.active:
@@ -132,14 +139,11 @@ class GoogleAdsCustomerMatchAbstractUploaderDoFn(beam.DoFn):
 
     self._assert_execution_is_valid(execution)
 
-    customer_id = execution.account_config.google_ads_account_id.replace('-', '')
+    customer_id = self._get_customer_id(execution.account_config, execution.destination)
 
     # get API services
-    user_list_service = self._get_user_list_service(
-      customer_id)
     offline_user_data_job_service = self._get_offline_user_data_job_service(
       customer_id)
-
 
     list_resource_name = self._create_list_if_it_does_not_exist(
       customer_id, execution.destination.destination_metadata[0],

--- a/megalist_dataflow/uploaders/utils.py
+++ b/megalist_dataflow/uploaders/utils.py
@@ -13,31 +13,30 @@
 # limitations under the License.
 
 import datetime
-from models.execution import DestinationType
-from models.execution import Execution
-import pytz
 import logging
+import pytz
 
+from google.ads.googleads.client import GoogleAdsClient
+from google.ads.googleads import oauth2
 
 MAX_RETRIES = 3
 
 timezone = pytz.timezone('America/Sao_Paulo')
 
 
-def get_ads_service(service_name, version, oauth_credentials, developer_token,
-                    customer_id):
-    from google.ads.googleads.client import GoogleAdsClient
-    from google.ads.googleads import oauth2
-
+def get_ads_client(oauth_credentials, developer_token, customer_id):
     oauth2_client = oauth2.get_installed_app_credentials(
         oauth_credentials.get_client_id(), oauth_credentials.get_client_secret(),
         oauth_credentials.get_refresh_token())
 
-    client = GoogleAdsClient(
+    return GoogleAdsClient(
         oauth2_client, developer_token,
         login_customer_id=customer_id)
 
-    return client.get_service(service_name, version=version)
+
+def get_ads_service(service_name, version, oauth_credentials, developer_token,
+                    customer_id):
+    return get_ads_client(oauth_credentials, developer_token, customer_id).get_service(service_name, version=version)
 
 
 def format_date(date):

--- a/megalist_dataflow/uploaders/utils.py
+++ b/megalist_dataflow/uploaders/utils.py
@@ -16,8 +16,7 @@ import datetime
 import logging
 import pytz
 
-from google.ads.googleads.client import GoogleAdsClient
-from google.ads.googleads import oauth2
+
 
 MAX_RETRIES = 3
 
@@ -25,6 +24,9 @@ timezone = pytz.timezone('America/Sao_Paulo')
 
 
 def get_ads_client(oauth_credentials, developer_token, customer_id):
+    from google.ads.googleads.client import GoogleAdsClient
+    from google.ads.googleads import oauth2
+
     oauth2_client = oauth2.get_installed_app_credentials(
         oauth_credentials.get_client_id(), oauth_credentials.get_client_secret(),
         oauth_credentials.get_refresh_token())


### PR DESCRIPTION
Two changes are included:

- Added possibility to setup an Ads account for each Customer Match destination. This replaces the Ads account present on the Intro tab for that destination only.
- Fix: customer match audience creation fails when there's a homonym list on a MCC above the target account.