### PR TITLE
Enable missing values in customer match

### DIFF
--- a/megalista_dataflow/mappers/ads_user_list_pii_hashing_mapper_test.py
+++ b/megalista_dataflow/mappers/ads_user_list_pii_hashing_mapper_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from mappers.ads_user_list_pii_hashing_mapper import AdsUserListPIIHashingMapper
-
 from models.execution import Batch
 
 
@@ -37,34 +36,66 @@ def test_get_should_hash_fields():
 def test_pii_hashing(mocker):
 
     users = [{
-        "email": "john@doe.com",
-        "mailing_address_first_name": "John",
-        "mailing_address_last_name": "Doe",
-        "mailing_address_zip": "12345",
-        "mailing_address_country": "US"
-    },
-        {
-            "email": "jane@doe.com",
-            "mailing_address_first_name": "Jane",
+            "email": "john@doe.com",
+            "phone": "+551199999999",
+            "mailing_address_first_name": "John ",
             "mailing_address_last_name": "Doe",
             "mailing_address_zip": "12345",
             "mailing_address_country": "US"
-        }]
+        },
+        {
+            "email": "jane@doe.com",
+            "phone": "+551199999910",
+            "mailing_address_first_name": "Jane",
+            "mailing_address_last_name": " Doe",
+            "mailing_address_zip": "12345",
+            "mailing_address_country": "US"
+        },
+        {
+            "email": "only@email.com",
+            "phone": None,
+            "mailing_address_first_name": "",
+            "mailing_address_last_name": "",
+            "mailing_address_zip": "",
+            "mailing_address_country": ""
+        },
+        {
+            "email": "",
+            "phone": "+551199999910",
+            "mailing_address_first_name": "",
+            "mailing_address_last_name": "",
+            "mailing_address_zip": "",
+            "mailing_address_country": ""
+        },
+        {
+            "phone": "+551199999911",
+            "mailing_address_first_name": "Incomplete",
+            "mailing_address_last_name": "Register",
+            "mailing_address_zip": None,
+        },
+        {
+            "phone": "",
+            "mailing_address_first_name": "Incomplete",
+            "mailing_address_last_name": None,
+            "mailing_address_zip": None,
+        }
+    ]
 
     # Execution mock
     execution = mocker.MagicMock()
     execution.destination.destination_metadata = ['Audience', 'ADD']
 
-    batch = Batch(execution, [users[0], users[1]])
+    batch = Batch(execution, users)
 
     # Call
     hasher = AdsUserListPIIHashingMapper()
     hashed = hasher.hash_users(batch).elements
 
-    assert len(hashed) == 2
+    assert len(hashed) == 5
 
     assert hashed[0] == {
         'hashed_email': 'd709f370e52b57b4eb75f04e2b3422c4d41a05148cad8f81776d94a048fb70af',
+        'hashed_phone_number': 'a58d4dce9db87c65ebb6137f91edb9bbe7f274f5b0d07eea82f756ea70532b9c',
         'address_info': {
             'country_code': 'US',
             'hashed_first_name': '96d9632f363564cc3032521409cf22a852f2032eec099ed5967c0d000cec607a',
@@ -74,12 +105,19 @@ def test_pii_hashing(mocker):
 
     assert hashed[1] == {
         'hashed_email': '7c815580ad3844bcb627c74d24eaf700e1a711d9c23e9beb62ab8d28e8cb7954',
+        'hashed_phone_number': 'd9303375de7036858c05f5836dd6db59d7f66899d3c8f85fbf09a8b60c79b236',
         'address_info': {
             'country_code': 'US',
             'hashed_first_name': '81f8f6dde88365f3928796ec7aa53f72820b06db8664f5fe76a7eb13e24546a2',
             'hashed_last_name': '799ef92a11af918e3fb741df42934f3b568ed2d93ac1df74f1b8d41a27932a6f',
             'postal_code': '12345'
         }}
+
+    assert hashed[2] == {'hashed_email': '785af30a27e429e1a2dc2f5e589d59f268239db551c3af29821eb0b3f05d40af'}
+
+    assert hashed[3] == {'hashed_phone_number': 'd9303375de7036858c05f5836dd6db59d7f66899d3c8f85fbf09a8b60c79b236'}
+
+    assert hashed[4] == {'hashed_phone_number': 'd8d1da09dd3584315610e314b781d0b964a260e6311879930aa2ff678a897753'}
 
 
 def test_avoid_pii_hashing(mocker):

--- a/megalista_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
@@ -205,7 +205,7 @@ class GoogleAdsCustomerMatchAbstractUploaderDoFn(beam.DoFn):
 
   def get_filtered_rows(self, rows: List[Any],
                         keys: List[str]) -> List[Dict[str, Any]]:
-    return [{key: row.get(key) for key in keys} for row in rows]
+    return [{key: row.get(key) for key in keys if key in row} for row in rows]
 
   def get_list_definition(self, account_config: AccountConfig,
                           destination_metadata: List[str]) -> Dict[str, Any]:

--- a/megalista_dataflow/uploaders/google_ads/customer_match/contact_info_uploader_test.py
+++ b/megalista_dataflow/uploaders/google_ads/customer_match/contact_info_uploader_test.py
@@ -1,0 +1,99 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from apache_beam.options.value_provider import StaticValueProvider
+import pytest
+from uploaders.google_ads.conversions.google_ads_offline_conversions_uploader import GoogleAdsOfflineUploaderDoFn
+from models.execution import AccountConfig
+from models.execution import Destination
+from models.execution import DestinationType
+from models.execution import Execution
+from models.execution import Source
+from models.execution import SourceType
+from models.execution import Batch
+from models.oauth_credentials import OAuthCredentials
+
+_account_config = AccountConfig('account_id', False, 'ga_account_id', '', '')
+
+
+@pytest.fixture
+def uploader(mocker):
+  mocker.patch('google.ads.googleads.client.GoogleAdsClient')
+  mocker.patch('google.ads.googleads.oauth2')
+  credential_id = StaticValueProvider(str, 'id')
+  secret = StaticValueProvider(str, 'secret')
+  access = StaticValueProvider(str, 'access')
+  refresh = StaticValueProvider(str, 'refresh')
+  credentials = OAuthCredentials(credential_id, secret, access, refresh)
+  return GoogleAdsOfflineUploaderDoFn(credentials,
+                                      StaticValueProvider(str, 'devtoken'))
+
+
+def test_get_service(mocker, uploader):
+  assert uploader._get_oc_service(mocker.ANY) is not None
+
+
+def test_not_active(mocker, caplog):
+  credential_id = StaticValueProvider(str, 'id')
+  secret = StaticValueProvider(str, 'secret')
+  access = StaticValueProvider(str, 'access')
+  refresh = StaticValueProvider(str, 'refresh')
+  credentials = OAuthCredentials(credential_id, secret, access, refresh)
+  uploader_dofn = GoogleAdsOfflineUploaderDoFn(credentials, None)
+  mocker.patch.object(uploader_dofn, '_get_oc_service')
+  uploader_dofn.process(Batch(None, []))
+  uploader_dofn._get_oc_service.assert_not_called()
+  assert 'Skipping upload, parameters not configured.' in caplog.text
+
+def test_conversion_upload(mocker, uploader):
+  mocker.patch.object(uploader, '_get_oc_service')
+  conversion_name = 'user_list'
+  destination = Destination(
+      'dest1', DestinationType.ADS_OFFLINE_CONVERSION, ['user_list'])
+  source = Source('orig1', SourceType.BIG_QUERY, ['dt1', 'buyers'])
+  execution = Execution(_account_config, source, destination)
+
+  time1 = '2020-04-09T14:13:55.0005'
+  time1_result = '2020-04-09 14:13:55-03:00'
+
+  time2 = '2020-04-09T13:13:55.0005'
+  time2_result = '2020-04-09 13:13:55-03:00'
+
+  batch = Batch(execution, [{
+          'time': time1,
+          'amount': '123',
+          'gclid': '456'
+      },{
+          'time': time2,
+          'amount': '234',
+          'gclid': '567'
+      }])
+  uploader.process(batch)
+
+  uploader._get_oc_service.return_value.upload_click_conversions.assert_any_call(request = {
+    'customer_id': 'account_id',
+    'partial_failure': False,
+    'validate_only': False,
+    'conversions': [{
+      'conversion_action': None,
+      'conversion_date_time': time1_result,
+      'conversion_value': 123,
+      'gclid': '456'
+    }, {
+      'conversion_action': None,
+      'conversion_date_time': time2_result,
+      'conversion_value': 234,
+      'gclid': '567'
+    }]
+  })


### PR DESCRIPTION
This PR aims to support a data source with missing values for keys in Customer Match.
Null and empty values are treated as missing and the key isn't sent only in the corresponding line.

For example:\

phone    |.   email.    |    adress
32431.     a@a.com.       null 
  ''.        b@a.com.     06578

The datasource will generate a request ignoring the null address and empty phone, but sending the other values.