### PR TITLE
Specifying scopes on "google" terraform provider.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,3 +1,13 @@
+provider "google" {
+    scopes = [
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/compute",
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/ndev.clouddns.readwrite",
+        "https://www.googleapis.com/auth/devstorage.full_control"
+    ]
+}
+
 data "google_client_config" "current" {
 }
 


### PR DESCRIPTION
These scopes are exactly the default ones, according to the documentation, but the deployment was failing without this configuration by missing the scope "https://www.googleapis.com/auth/userinfo.email".