### PR TITLE
Update Campaign Manager uploader to handle decimal fields

### DIFF
--- a/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader.py
+++ b/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader.py
@@ -107,7 +107,7 @@ class CampaignManagerConversionUploaderDoFn(beam.DoFn):
         to_upload['matchId'] = conversion['matchId']
 
       if 'value' in conversion:
-        to_upload['value'] = conversion['value']
+        to_upload['value'] = float(conversion['value'])
       if 'quantity' in conversion:
         to_upload['quantity'] = conversion['quantity']
       if 'customVariables' in conversion:


### PR DESCRIPTION
Numeric field types in BigQuery are read as [Python Decimal classes](https://docs.python.org/3/library/decimal.html). These objects cannot be serialised (by default) so the upload fails. This change converts the value to a float, so numeric BQ fields can be serialised.