### PR TITLE
Cm offline conv timestamp

### DIFF
--- a/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader.py
+++ b/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader.py
@@ -121,6 +121,9 @@ class CampaignManagerConversionUploaderDoFn(beam.DoFn):
           custom_variables.append(cv)
         to_upload['customVariables'] = custom_variables
 
+      if 'timestamp' in conversion:
+        to_upload['timestampMicros'] = utils.get_timestamp_micros(conversion['timestamp'])
+
       conversions.append(to_upload)
 
     request_body = {

--- a/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader_test.py
+++ b/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader_test.py
@@ -71,8 +71,7 @@ def test_conversion_upload(mocker, uploader):
         'gclid': '123',
         'timestamp': '2021-11-30T12:00:00.000'
     }, {
-        'gclid': '456',
-        'timestamp': '2021-11-30T12:00:00.000'
+        'gclid': '456'
     }]), current_time)
 
     # convert 2021-11-30T12:00:00.000 to timestampMicros
@@ -90,7 +89,7 @@ def test_conversion_upload(mocker, uploader):
             'floodlightActivityId': floodlight_activity_id,
             'floodlightConfigurationId': floodlight_configuration_id,
             'ordinal': math.floor(current_time * 10e5),
-            'timestampMicros': timestamp_micros
+            'timestampMicros': math.floor(current_time * 10e5)
         }],
     }
 

--- a/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader_test.py
+++ b/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader_test.py
@@ -15,6 +15,7 @@ import decimal
 import math
 import time
 import logging
+from datetime import datetime, timezone
 
 from apache_beam.options.value_provider import StaticValueProvider
 from uploaders.campaign_manager.campaign_manager_conversion_uploader import CampaignManagerConversionUploaderDoFn
@@ -67,10 +68,15 @@ def test_conversion_upload(mocker, uploader):
     current_time = time.time()
 
     uploader._do_process(Batch(execution, [{
-        'gclid': '123'
+        'gclid': '123',
+        'timestamp': '2021-11-30T12:00:00.000'
     }, {
-        'gclid': '456'
+        'gclid': '456',
+        'timestamp': '2021-11-30T12:00:00.000'
     }]), current_time)
+
+    # convert 2021-11-30T12:00:00.000 to timestampMicros
+    timestamp_micros = math.floor(datetime.strptime('2021-11-30T12:00:00.000', '%Y-%m-%dT%H:%M:%S.%f').timestamp() * 10e5)
 
     expected_body = {
         'conversions': [{
@@ -78,13 +84,13 @@ def test_conversion_upload(mocker, uploader):
             'floodlightActivityId': floodlight_activity_id,
             'floodlightConfigurationId': floodlight_configuration_id,
             'ordinal': math.floor(current_time * 10e5),
-            'timestampMicros': math.floor(current_time * 10e5)
+            'timestampMicros': timestamp_micros
         }, {
             'gclid': '456',
             'floodlightActivityId': floodlight_activity_id,
             'floodlightConfigurationId': floodlight_configuration_id,
             'ordinal': math.floor(current_time * 10e5),
-            'timestampMicros': math.floor(current_time * 10e5)
+            'timestampMicros': timestamp_micros
         }],
     }
 

--- a/megalista_dataflow/uploaders/utils.py
+++ b/megalista_dataflow/uploaders/utils.py
@@ -15,7 +15,7 @@
 import datetime
 import logging
 import pytz
-
+import math
 
 
 MAX_RETRIES = 3
@@ -51,6 +51,14 @@ def format_date(date):
     str_timezone = pdate.strftime("%z")
     return f'{datetime.datetime.strftime(pdate, "%Y-%m-%d %H:%M:%S")}{str_timezone[-5:-2]}:{str_timezone[-2:]}'
 
+def get_timestamp_micros(date):
+    if isinstance(date, datetime.datetime):
+        pdate = date
+    else:
+        pdate = datetime.datetime.strptime(date, '%Y-%m-%dT%H:%M:%S.%f')
+
+    return math.floor(pdate.timestamp() * 10e5)
+    
 
 def safe_process(logger):
     def deco(func):


### PR DESCRIPTION
Usage of timestamp on CM offline conversions.

Column timestamp with the same format as the ones used on Google Ads (e.g. 2021-12-07T19:43:00.000), optional (if not used, Megalista will keep using the timestamp on the moment of upload process as timestamp on CM)