### PR TITLE
Update CM API version from 3.4 to 3.5 due to deprecation in Jan 2022.

### DIFF
--- a/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader.py
+++ b/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader.py
@@ -45,7 +45,7 @@ class CampaignManagerConversionUploaderDoFn(beam.DoFn):
             'https://www.googleapis.com/auth/dfatrafficking',
             'https://www.googleapis.com/auth/ddmconversions'])
 
-    return build('dfareporting', 'v3.4', credentials=credentials)
+    return build('dfareporting', 'v3.5', credentials=credentials)
 
   def start_bundle(self):
     pass


### PR DESCRIPTION
Update CM API version from 3.4 to 3.5 due to deprecation in Jan 2022.