### PR TITLE
Enable ability to authenticate using MCC account for customer match uploads

### DIFF
--- a/megalista_dataflow/uploaders/google_ads/customer_match/contact_info_uploader_test.py
+++ b/megalista_dataflow/uploaders/google_ads/customer_match/contact_info_uploader_test.py
@@ -75,7 +75,7 @@ def test_upload_add_users(mocker, uploader):
     'resource_name': 'a',
   }
 
-  uploader._get_offline_user_data_job_service.assert_called_once_with('mcc_account_id') 
+  uploader._get_offline_user_data_job_service.assert_called_once_with('account_id') 
   uploader._get_offline_user_data_job_service.return_value.add_offline_user_data_job_operations.assert_called_once_with(
     request=data_insertion_payload
   )
@@ -120,7 +120,7 @@ def test_upload_replace_users(mocker, uploader):
     'resource_name': 'a',
   }
 
-  uploader._get_offline_user_data_job_service.assert_called_once_with('mcc_account_id') 
+  uploader._get_offline_user_data_job_service.assert_called_once_with('account_id') 
   uploader._get_offline_user_data_job_service.return_value.add_offline_user_data_job_operations.assert_called_once_with(
     request=data_insertion_payload
   )

--- a/megalista_dataflow/uploaders/google_ads/customer_match/contact_info_uploader_test.py
+++ b/megalista_dataflow/uploaders/google_ads/customer_match/contact_info_uploader_test.py
@@ -20,6 +20,7 @@ from models.oauth_credentials import OAuthCredentials
 from uploaders.google_ads.customer_match.contact_info_uploader import GoogleAdsCustomerMatchContactInfoUploaderDoFn
 
 _account_config = AccountConfig('account_id', False, 'ga_account_id', '', '')
+_mcc_account_config = AccountConfig('mcc_account_id', True, 'ga_account_id', '', '')
 
 
 @pytest.fixture
@@ -74,6 +75,7 @@ def test_upload_add_users(mocker, uploader):
     'resource_name': 'a',
   }
 
+  uploader._get_offline_user_data_job_service.assert_called_once_with('mcc_account_id') 
   uploader._get_offline_user_data_job_service.return_value.add_offline_user_data_job_operations.assert_called_once_with(
     request=data_insertion_payload
   )
@@ -118,8 +120,93 @@ def test_upload_replace_users(mocker, uploader):
     'resource_name': 'a',
   }
 
+  uploader._get_offline_user_data_job_service.assert_called_once_with('mcc_account_id') 
   uploader._get_offline_user_data_job_service.return_value.add_offline_user_data_job_operations.assert_called_once_with(
     request=data_insertion_payload
   )
 
+def test_upload_add_users_with_ads_account_override(mocker, uploader):
+  mocker.patch.object(uploader, '_get_offline_user_data_job_service')
 
+  uploader._get_offline_user_data_job_service.return_value.create_offline_user_data_job.return_value.resource_name = 'a'
+
+  destination = Destination(
+    'dest1', DestinationType.ADS_CUSTOMER_MATCH_CONTACT_INFO_UPLOAD, ['user_list', 'ADD', 'FALSE', '', 'override_account_id', ''])
+  source = Source('orig1', SourceType.BIG_QUERY, ['dt1', 'buyers'])
+  execution = Execution(_account_config, source, destination)
+
+  batch = Batch(execution, [{
+    'hashed_email': 'email1',
+    'hashed_phone_number': 'phone1',
+    'address_info': {
+      'hashed_first_name': 'first1',
+      'hashed_last_name': 'last1',
+      'country_code': 'country1',
+      'postal_code': 'postal1',
+    }
+  }])
+
+  uploader.process(batch)
+
+  data_insertion_payload = {
+    'enable_partial_failure': False,
+    'operations': [
+      {'create': {'user_identifiers': [{'hashed_email': 'email1'}]}},
+      {'create': {'user_identifiers': [{'address_info': {
+        'hashed_first_name': 'first1',
+        'hashed_last_name': 'last1',
+        'country_code': 'country1',
+        'postal_code': 'postal1'}},
+      ]}},
+      {'create': {'user_identifiers': [{'hashed_phone_number': 'phone1'}]}}
+    ],
+    'resource_name': 'a',
+  }
+
+  uploader._get_offline_user_data_job_service.assert_called_once_with('override_account_id') 
+  uploader._get_offline_user_data_job_service.return_value.add_offline_user_data_job_operations.assert_called_once_with(
+    request=data_insertion_payload
+  )
+
+def test_upload_add_users_with_mcc_account_override(mocker, uploader):
+  mocker.patch.object(uploader, '_get_offline_user_data_job_service')
+
+  uploader._get_offline_user_data_job_service.return_value.create_offline_user_data_job.return_value.resource_name = 'a'
+
+  destination = Destination(
+    'dest1', DestinationType.ADS_CUSTOMER_MATCH_CONTACT_INFO_UPLOAD, ['user_list', 'ADD', 'FALSE', '', 'override_account_id', ''])
+  source = Source('orig1', SourceType.BIG_QUERY, ['dt1', 'buyers'])
+  execution = Execution(_mcc_account_config, source, destination)
+
+  batch = Batch(execution, [{
+    'hashed_email': 'email1',
+    'hashed_phone_number': 'phone1',
+    'address_info': {
+      'hashed_first_name': 'first1',
+      'hashed_last_name': 'last1',
+      'country_code': 'country1',
+      'postal_code': 'postal1',
+    }
+  }])
+
+  uploader.process(batch)
+
+  data_insertion_payload = {
+    'enable_partial_failure': False,
+    'operations': [
+      {'create': {'user_identifiers': [{'hashed_email': 'email1'}]}},
+      {'create': {'user_identifiers': [{'address_info': {
+        'hashed_first_name': 'first1',
+        'hashed_last_name': 'last1',
+        'country_code': 'country1',
+        'postal_code': 'postal1'}},
+      ]}},
+      {'create': {'user_identifiers': [{'hashed_phone_number': 'phone1'}]}}
+    ],
+    'resource_name': 'a',
+  }
+
+  uploader._get_offline_user_data_job_service.assert_called_once_with('mcc_account_id') 
+  uploader._get_offline_user_data_job_service.return_value.add_offline_user_data_job_operations.assert_called_once_with(
+    request=data_insertion_payload
+  )


### PR DESCRIPTION
## Description
td;dr: When GoogleAdsMCC is set to TRUE, then use the GoogleAdsAccountId as the login-customer-id for customer match. 

Currently, we use the customer ID in the "Destinations" field (if available) as both the customer id, and the log-in customer id (when creating the Ads API client) when calling the Google Ads API, and only fall back to using the GoogleAdsAccountId if no customer ID is supplied. 

This is un-ideal since we are not able to authenticate at the MCC level, and therefore unable to use one Megalista deployment for uploading data to multiple child CIDs.

Since there is a GoogleAdsMCC field, as a user I expect Megalista to use the GoogleAdsAccountId as the log-in customer id if GoogleAdsMCC = TRUE. 

## Testing
* Deployed Megalista (with DEBUG log level for Ads API client) and verified that the login-customer-id header is set correctly when GoogleAdsMCC = TRUE. (MCC=9560465107, CID=5341114500):
```
2022-04-08T20:12:18.205241441ZReading from table ct_megalista_test_1.my-customer-match-list for Execution Origin name: my_customer_match_list. Action: DestinationType.ADS_CUSTOMER_MATCH_CONTACT_INFO_UPLOAD. Destination name: customer_match_test_1
Info
2022-04-08T20:12:25.366386413ZUploading 1 rows...
2022-04-08T20:12:30.143587589ZRequest ------- Method: /google.ads.googleads.v10.services.GoogleAdsService/SearchStream Host: googleads.googleapis.com Headers: { "developer-token": "REDACTED", "login-customer-id": "9560465107", "x-goog-api-client": "gl-python/3.8.12 grpc/1.43.0 gax/2.7.1 gccl/15.0.0", "x-goog-request-params": "customer_id=5341114500" } Request: customer_id: "5341114500" query: "SELECT user_list.resource_name, user_list.access_reason FROM user_list WHERE user_list.name=\'charlieliu_test_audience_list_2\' AND user_list.access_reason=\'OWNED\'" Response ------- Headers: { "content-disposition": "attachment", "request-id": "YMW5U4C6m_ZUh59Xdih0qw" } Response: None
2022-04-08T20:12:30.143780708ZRequest made: ClientCustomerId: 5341114500, Host: googleads.googleapis.com, Method: /google.ads.googleads.v10.services.GoogleAdsService/SearchStream, RequestId: YMW5U4C6m_ZUh59Xdih0qw, IsFault: False, FaultMessage: None
2022-04-08T20:12:30.144222021ZList charlieliu_test_audience_list_2 found with resource name: customers/5341114500/userLists/7176152189
Debug
2022-04-08T20:12:30.341757774ZRequest ------- Method: /google.ads.googleads.v10.services.OfflineUserDataJobService/CreateOfflineUserDataJob Host: googleads.googleapis.com Headers: { "developer-token": "REDACTED", "login-customer-id": "9560465107", "x-goog-api-client": "gl-python/3.8.12 grpc/1.43.0 gax/2.7.1 gccl/15.0.0", "x-goog-request-params": "customer_id=5341114500" } Request: customer_id: "5341114500" job { type_: CUSTOMER_MATCH_USER_LIST customer_match_user_list_metadata { user_list: "customers/5341114500/userLists/7176152189" } } Response ------- Headers: { "content-disposition": "attachment", "date": "Fri, 08 Apr 2022 20:12:30 GMT", "request-id": "gHoZGud_DajghlAVGOM8fg" } Response: resource_name: "customers/5341114500/offlineUserDataJobs/19858527900"
2022-04-08T20:12:30.341936111ZRequest made: ClientCustomerId: 5341114500, Host: googleads.googleapis.com, Method: /google.ads.googleads.v10.services.OfflineUserDataJobService/CreateOfflineUserDataJob, RequestId: gHoZGud_DajghlAVGOM8fg, IsFault: False, FaultMessage: None
2022-04-08T20:12:30.596240043ZRequest ------- Method: /google.ads.googleads.v10.services.OfflineUserDataJobService/AddOfflineUserDataJobOperations Host: googleads.googleapis.com Headers: { "developer-token": "REDACTED", "login-customer-id": "9560465107", "x-goog-api-client": "gl-python/3.8.12 grpc/1.43.0 gax/2.7.1 gccl/15.0.0", "x-goog-request-params": "resource_name=customers/5341114500/offlineUserDataJobs/19858527900" } Request: resource_name: "customers/5341114500/offlineUserDataJobs/19858527900" operations { create { user_identifiers { hashed_email: "05587b1819d835102161bbdda8dddf3fb25160d04e867c51e3cbf7a6b47d16e1" } } } operations { create { user_identifiers { address_info { hashed_first_name: "b9dd960c1753459a78115d3cb845a57d924b6877e805b08bd01086ccdf34433c" hashed_last_name: "eb9e5c2a708dd6c4b57088c96553de8303cf431b5e42a0630625fa08d8dd6d6b" country_code: "Canada" postal_code: "M4S2X1" } } } } operations { create { user_identifiers { hashed_phone_number: "12e02f734d12cc372b42c1c87cf347dc4e3cca9e74cc299ba1c90d20df3eda5d" } } } enable_partial_failure: false Response ------- Headers: { "content-disposition": "attachment", "date": "Fri, 08 Apr 2022 20:12:30 GMT", "request-id": "UD07KscwlNqtsXAL9f-5Iw" } Response:
2022-04-08T20:12:30.596423625ZRequest made: ClientCustomerId: 5341114500, Host: googleads.googleapis.com, Method: /google.ads.googleads.v10.services.OfflineUserDataJobService/AddOfflineUserDataJobOperations, RequestId: UD07KscwlNqtsXAL9f-5Iw, IsFault: False, FaultMessage: None
2022-04-08T20:12:30.600431919ZRunning job customers/5341114500/offlineUserDataJobs/19858527900
2022-04-08T20:12:31.005608558ZRequest ------- Method: /google.ads.googleads.v10.services.OfflineUserDataJobService/RunOfflineUserDataJob Host: googleads.googleapis.com Headers: { "developer-token": "REDACTED", "login-customer-id": "9560465107", "x-goog-api-client": "gl-python/3.8.12 grpc/1.43.0 gax/2.7.1 gccl/15.0.0", "x-goog-request-params": "resource_name=customers/5341114500/offlineUserDataJobs/19858527900" } Request: resource_name: "customers/5341114500/offlineUserDataJobs/19858527900" Response ------- Headers: { "content-disposition": "attachment", "date": "Fri, 08 Apr 2022 20:12:31 GMT", "request-id": "3Rcuycza-jVvCl_Ah3IWQA" } Response: name: "customers/5341114500/operations/CjRjdXN0b21lcnMvNTM0MTExNDUwMC9vZmZsaW5lVXNlckRhdGFKb2JzLzE5ODU4NTI3OTAwEAo="
2022-04-08T20:12:31.005815029ZRequest made: ClientCustomerId: 5341114500, Host: googleads.googleapis.com, Method: /google.ads.googleads.v10.services.OfflineUserDataJobService/RunOfflineUserDataJob, RequestId: 3Rcuycza-jVvCl_Ah3IWQA, IsFault: False, FaultMessage: None

```
* Ran unit tests (everything passing):
```
charlieliu@cloudshell:~/megalista_test/megalista (ct-megalista-test)$ python3 -m pytest
===================================================================================================================================== test session starts ======================================================================================================================================
platform linux -- Python 3.9.2, pytest-5.4.3, py-1.11.0, pluggy-0.13.1
rootdir: /home/charlieliu/megalista
plugins: cov-2.10.0, mock-3.2.0, requests-mock-1.8.0
collected 45 items                                                                                                                                                                                                                                                                             

megalista_dataflow/mappers/ads_user_list_pii_hashing_mapper_test.py ...                                                                                                                                                                                                                  [  6%]
megalista_dataflow/models/oauth_credentials_test.py .                                                                                                                                                                                                                                    [  8%]
megalista_dataflow/models/options_test.py .                                                                                                                                                                                                                                              [ 11%]
megalista_dataflow/uploaders/big_query/transactional_events_results_writer_test.py ...                                                                                                                                                                                                   [ 17%]
megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader_test.py ......                                                                                                                                                                                        [ 31%]
megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_uploader_test.py ...                                                                                                                                                                                  [ 37%]
megalista_dataflow/uploaders/google_ads/conversions/google_ads_ssd_uploader_test.py ...                                                                                                                                                                                                  [ 44%]
megalista_dataflow/uploaders/google_ads/customer_match/contact_info_uploader_test.py ..                                                                                                                                                                                                  [ 48%]
megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol_test.py ..........                                                                                                                                                                                 [ 71%]
megalista_dataflow/uploaders/google_analytics/google_analytics_data_import_eraser_test.py ....                                                                                                                                                                                           [ 80%]
megalista_dataflow/uploaders/google_analytics/google_analytics_data_import_uploader_test.py ..                                                                                                                                                                                           [ 84%]
megalista_dataflow/uploaders/google_analytics/google_analytics_user_list_uploader_test.py .......          
```