### PR TITLE
Adjusting CM account/profile references

### DIFF
--- a/cloud_config/configuration_sample.json
+++ b/cloud_config/configuration_sample.json
@@ -3,7 +3,7 @@
   "GoogleAdsMCC": false,
   "AppId": "",
   "GoogleAnalyticsAccountId": "",
-  "CampaignManagerAccountId": "",
+  "CampaignManagerProfileId": "",
   "Sources": [
     {
       "Name": "example Ads offline conversions source",

--- a/megalista_dataflow/models/execution.py
+++ b/megalista_dataflow/models/execution.py
@@ -53,13 +53,13 @@ class AccountConfig:
         google_ads_account_id: str,
         mcc: bool,
         google_analytics_account_id: str,
-        campaign_manager_account_id: str,
+        campaign_manager_profile_id: str,
         app_id: str,
     ):
         self._google_ads_account_id = google_ads_account_id
         self._mcc = mcc
         self._google_analytics_account_id = google_analytics_account_id
-        self._campaign_manager_account_id = campaign_manager_account_id
+        self._campaign_manager_profile_id = campaign_manager_profile_id
         self._app_id = app_id
 
     @property
@@ -75,8 +75,8 @@ class AccountConfig:
         return self._google_analytics_account_id
 
     @property
-    def campaign_manager_account_id(self) -> str:
-        return self._campaign_manager_account_id
+    def campaign_manager_profile_id(self) -> str:
+        return self._campaign_manager_profile_id
 
     @property
     def app_id(self) -> str:
@@ -87,7 +87,7 @@ class AccountConfig:
             'google_ads_account_id' : self.google_ads_account_id,
             'mcc': self.mcc,
             'google_analytics_account_id': self.google_analytics_account_id,
-            'campaign_manager_account_id': self.campaign_manager_account_id,
+            'campaign_manager_profile_id': self.campaign_manager_profile_id,
             'app_id': self.app_id,
         }
 
@@ -97,7 +97,7 @@ class AccountConfig:
             dict_account_config['google_ads_account_id'],
             dict_account_config['mcc'],
             dict_account_config['google_analytics_account_id'],
-            dict_account_config['campaign_manager_account_id'],
+            dict_account_config['campaign_manager_profile_id'],
             dict_account_config['app_id'],
         )
 
@@ -107,7 +107,7 @@ class AccountConfig:
             f"Google Ads Customer Id: {self.google_ads_account_id}\n\t"
             f"Google Ads MCC: {self._mcc}\n\t"
             f"Google Analytics Account Id: {self.google_analytics_account_id}\n\t"
-            f"Campaign Manager Account Id: {self.campaign_manager_account_id}\n\t"
+            f"Campaign Manager Account Id: {self.campaign_manager_profile_id}\n\t"
             f"Play Store App Id: {self.app_id}"
         )
 
@@ -115,7 +115,7 @@ class AccountConfig:
         return (
             self.google_ads_account_id == other.google_ads_account_id
             and self.google_analytics_account_id == other.google_analytics_account_id
-            and self.campaign_manager_account_id == other.campaign_manager_account_id
+            and self.campaign_manager_profile_id == other.campaign_manager_profile_id
             and self.app_id == other.app_id
         )
 
@@ -124,7 +124,7 @@ class AccountConfig:
             (
                 self.google_ads_account_id,
                 self.google_analytics_account_id,
-                self.campaign_manager_account_id,
+                self.campaign_manager_profile_id,
                 self.app_id,
             )
         )

--- a/megalista_dataflow/sources/firestore_execution_source.py
+++ b/megalista_dataflow/sources/firestore_execution_source.py
@@ -62,9 +62,9 @@ class FirestoreExecutionSource(BaseBoundedSource):
     mcc = False if mcc_trix is None else bool(distutils.util.strtobool(mcc_trix))
     app_id = account_data.get('app_id', 'empty')
     google_analytics_account_id = account_data.get('google_analytics_account_id', 'empty')
-    campaign_manager_account_id = account_data.get('campaign_manager_account_id', 'empty')
+    campaign_manager_profile_id = account_data.get('campaign_manager_profile_id', 'empty')
     
-    account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_account_id, app_id)
+    account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_profile_id, app_id)
     logging.getLogger("megalista.FirestoreExecutionSource").info(f"Loaded: {account_config}")
     
     sources = self._read_sources(entries)

--- a/megalista_dataflow/sources/json_execution_source.py
+++ b/megalista_dataflow/sources/json_execution_source.py
@@ -49,6 +49,10 @@ class JsonExecutionSource(BaseBoundedSource):
     app_id = self._json_config.get_value(json_data, "AppId")
     google_analytics_account_id = self._json_config.get_value(json_data, "GoogleAnalyticsAccountId")
     campaign_manager_profile_id = self._json_config.get_value(json_data, "CampaignManagerProfileId")
+    
+    if campaign_manager_profile_id is None:
+    campaign_manager_profile_id = self._json_config.get_value(sheet_id, "CampaignManagerAccountId")
+    
     account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_profile_id, app_id)
     logging.getLogger("megalista.JsonExecutionSource").info(f"Loaded: {account_config}")
 

--- a/megalista_dataflow/sources/json_execution_source.py
+++ b/megalista_dataflow/sources/json_execution_source.py
@@ -48,8 +48,8 @@ class JsonExecutionSource(BaseBoundedSource):
     mcc = False if mcc_json is None else mcc_json
     app_id = self._json_config.get_value(json_data, "AppId")
     google_analytics_account_id = self._json_config.get_value(json_data, "GoogleAnalyticsAccountId")
-    campaign_manager_account_id = self._json_config.get_value(json_data, "CampaignManagerProfileId")
-    account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_account_id, app_id)
+    campaign_manager_profile_id = self._json_config.get_value(json_data, "CampaignManagerProfileId")
+    account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_profile_id, app_id)
     logging.getLogger("megalista.JsonExecutionSource").info(f"Loaded: {account_config}")
 
     sources = self._read_sources(self._json_config, json_data)

--- a/megalista_dataflow/sources/json_execution_source.py
+++ b/megalista_dataflow/sources/json_execution_source.py
@@ -48,7 +48,7 @@ class JsonExecutionSource(BaseBoundedSource):
     mcc = False if mcc_json is None else mcc_json
     app_id = self._json_config.get_value(json_data, "AppId")
     google_analytics_account_id = self._json_config.get_value(json_data, "GoogleAnalyticsAccountId")
-    campaign_manager_account_id = self._json_config.get_value(json_data, "CampaignManagerAccountId")
+    campaign_manager_account_id = self._json_config.get_value(json_data, "CampaignManagerProfileId")
     account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_account_id, app_id)
     logging.getLogger("megalista.JsonExecutionSource").info(f"Loaded: {account_config}")
 

--- a/megalista_dataflow/sources/spreadsheet_execution_source.py
+++ b/megalista_dataflow/sources/spreadsheet_execution_source.py
@@ -49,7 +49,7 @@ class SpreadsheetExecutionSource(BaseBoundedSource):
     mcc = False if mcc_trix is None else bool(distutils.util.strtobool(mcc_trix))
     app_id = self._sheets_config.get_value(sheet_id, "AppId")
     google_analytics_account_id = self._sheets_config.get_value(sheet_id, "GoogleAnalyticsAccountId")
-    campaign_manager_account_id = self._sheets_config.get_value(sheet_id, "CampaignManagerAccountId")
+    campaign_manager_account_id = self._sheets_config.get_value(sheet_id, "CampaignManagerProfileId")
     account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_account_id, app_id)
     logging.getLogger("megalista.SpreadsheetExecutionSource").info(f"Loaded: {account_config}")
 

--- a/megalista_dataflow/sources/spreadsheet_execution_source.py
+++ b/megalista_dataflow/sources/spreadsheet_execution_source.py
@@ -49,8 +49,8 @@ class SpreadsheetExecutionSource(BaseBoundedSource):
     mcc = False if mcc_trix is None else bool(distutils.util.strtobool(mcc_trix))
     app_id = self._sheets_config.get_value(sheet_id, "AppId")
     google_analytics_account_id = self._sheets_config.get_value(sheet_id, "GoogleAnalyticsAccountId")
-    campaign_manager_account_id = self._sheets_config.get_value(sheet_id, "CampaignManagerProfileId")
-    account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_account_id, app_id)
+    campaign_manager_profile_id = self._sheets_config.get_value(sheet_id, "CampaignManagerProfileId")
+    account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_profile_id, app_id)
     logging.getLogger("megalista.SpreadsheetExecutionSource").info(f"Loaded: {account_config}")
 
     sources = self._read_sources(self._sheets_config, sheet_id)

--- a/megalista_dataflow/sources/spreadsheet_execution_source.py
+++ b/megalista_dataflow/sources/spreadsheet_execution_source.py
@@ -50,6 +50,10 @@ class SpreadsheetExecutionSource(BaseBoundedSource):
     app_id = self._sheets_config.get_value(sheet_id, "AppId")
     google_analytics_account_id = self._sheets_config.get_value(sheet_id, "GoogleAnalyticsAccountId")
     campaign_manager_profile_id = self._sheets_config.get_value(sheet_id, "CampaignManagerProfileId")
+    
+    if campaign_manager_profile_id is None:
+      campaign_manager_profile_id = self._sheets_config.get_value(sheet_id, "CampaignManagerAccountId")
+        
     account_config = AccountConfig(google_ads_id, mcc, google_analytics_account_id, campaign_manager_profile_id, app_id)
     logging.getLogger("megalista.SpreadsheetExecutionSource").info(f"Loaded: {account_config}")
 

--- a/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader.py
+++ b/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader.py
@@ -75,7 +75,7 @@ class CampaignManagerConversionUploaderDoFn(MegalistaUploader):
         execution,
         execution.destination.destination_metadata[0],
         execution.destination.destination_metadata[1],
-        execution.account_config.campaign_manager_account_id,
+        execution.account_config.campaign_manager_profile_id,
         timestamp,
         batch.elements)
 
@@ -84,7 +84,7 @@ class CampaignManagerConversionUploaderDoFn(MegalistaUploader):
       execution,
       floodlight_activity_id,
       floodlight_configuration_id,
-      campaign_manager_account_id,
+      campaign_manager_profile_id,
       timestamp,
       rows):
 
@@ -135,7 +135,7 @@ class CampaignManagerConversionUploaderDoFn(MegalistaUploader):
     logger.info(f'Conversions: \n{conversions}')
 
     request = service.conversions().batchinsert(
-        profileId=campaign_manager_account_id, body=request_body)
+        profileId=campaign_manager_profile_id, body=request_body)
     response = request.execute()
 
     if response['hasFailures']:

--- a/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader_test.py
+++ b/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader_test.py
@@ -33,7 +33,7 @@ from models.oauth_credentials import OAuthCredentials
 from uploaders.campaign_manager.campaign_manager_conversion_uploader import CampaignManagerConversionUploaderDoFn
 
 _account_config = AccountConfig(mcc=False,
-                                campaign_manager_account_id='dcm_profile_id',
+                                campaign_manager_profile_id='dcm_profile_id',
                                 google_ads_account_id='',
                                 google_analytics_account_id='',
                                 app_id='')


### PR DESCRIPTION
Campaign Manager's API authentication is done through a Profile Id, not Account Id. ML's references "Account Id" on multiple places which can be confusing and misleading. 

Updated all references to CM Account Id to CM Profile Id. Also, added a _if_ to handle request from older versions of the configuration Trix and JSON. 

Important: the Named Ranges in the template trix has to be updated to CampaignManagerProfileId, as well as the JSON generated off of it.