### PR TITLE
Ads replace fix 

### DIFF
--- a/megalista_dataflow/mappers/abstract_list_pii_hashing_mapper.py
+++ b/megalista_dataflow/mappers/abstract_list_pii_hashing_mapper.py
@@ -74,5 +74,5 @@ class ListPIIHashingMapper:
         return Batch(
             batch.execution, 
             [element for element in hashed_elements if element],
-            batch.iterarion
+            batch.iteration
         )

--- a/megalista_dataflow/mappers/abstract_list_pii_hashing_mapper.py
+++ b/megalista_dataflow/mappers/abstract_list_pii_hashing_mapper.py
@@ -72,5 +72,7 @@ class ListPIIHashingMapper:
         ]
 
         return Batch(
-            batch.execution, [element for element in hashed_elements if element]
+            batch.execution, 
+            [element for element in hashed_elements if element],
+            batch.iterarion
         )

--- a/megalista_dataflow/models/execution.py
+++ b/megalista_dataflow/models/execution.py
@@ -293,11 +293,11 @@ class Batch:
         self,
         execution: Execution,
         elements: List[Dict[str, Union[str, Dict[str, str]]]],
-        iterarion: int = 1,
+        iteration: int = 1,
     ):
         self._execution = execution
         self._elements = elements
-        self._iteration = iterarion
+        self._iteration = iteration
 
     @property
     def execution(self) -> Execution:
@@ -308,7 +308,7 @@ class Batch:
         return self._elements
 
     @property
-    def iterarion(self) -> int:
+    def iteration(self) -> int:
         return self._iteration
 
     def __str__(self):

--- a/megalista_dataflow/models/execution.py
+++ b/megalista_dataflow/models/execution.py
@@ -293,9 +293,11 @@ class Batch:
         self,
         execution: Execution,
         elements: List[Dict[str, Union[str, Dict[str, str]]]],
+        iterarion: int = 1,
     ):
         self._execution = execution
         self._elements = elements
+        self._iteration = iterarion
 
     @property
     def execution(self) -> Execution:
@@ -304,6 +306,10 @@ class Batch:
     @property
     def elements(self) -> List[Dict[str, Union[str, Dict[str, str]]]]:
         return self._elements
+
+    @property
+    def iterarion(self) -> int:
+        return self._iteration
 
     def __str__(self):
         return f"Execution: {self._execution}. Elements: {self._elements}"

--- a/megalista_dataflow/sources/batches_from_executions.py
+++ b/megalista_dataflow/sources/batches_from_executions.py
@@ -133,14 +133,17 @@ class BatchesFromExecutions(beam.PTransform):
         def process(self, grouped_elements):
             # grouped_elements[0] is the grouping key, the execution
             execution = grouped_elements[0]
-            batch: List[Any] = []
+            batch: List[Any] = []        
+            # Keeps track of the batch iteration
+            iteration = 1
             # grouped_elements[1] is the list of elements
             for i, element in enumerate(grouped_elements[1]):
                 if i != 0 and i % self._batch_size == 0:
-                    yield Batch(execution, batch)
+                    yield Batch(execution, batch, iteration)
+                    iteration += 1
                     batch = []
                 batch.append(element)
-            yield Batch(execution, batch)
+            yield Batch(execution, batch, iteration)
 
     def __init__(
         self,

--- a/megalista_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
@@ -221,7 +221,8 @@ class GoogleAdsCustomerMatchAbstractUploaderDoFn(MegalistaUploader):
         rows = self.get_filtered_rows(batch.elements, self.get_row_keys())
 
         operations = []
-        if self._get_remove_all(execution.destination.destination_metadata[1]):
+        # Only removes all at the first interation. Otherwise, skip it
+        if (self._get_remove_all(execution.destination.destination_metadata[1]) and batch.iterarion == 1):
             operations.append({
                 'remove_all': True
             })

--- a/megalista_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/customer_match/abstract_uploader.py
@@ -222,7 +222,7 @@ class GoogleAdsCustomerMatchAbstractUploaderDoFn(MegalistaUploader):
 
         operations = []
         # Only removes all at the first interation. Otherwise, skip it
-        if (self._get_remove_all(execution.destination.destination_metadata[1]) and batch.iterarion == 1):
+        if (self._get_remove_all(execution.destination.destination_metadata[1]) and batch.iteration == 1):
             operations.append({
                 'remove_all': True
             })

--- a/megalista_dataflow/uploaders/google_ads/customer_match/contact_info_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/customer_match/contact_info_uploader.py
@@ -25,11 +25,18 @@ from models.execution import DestinationType, AccountConfig
 class GoogleAdsCustomerMatchContactInfoUploaderDoFn(GoogleAdsCustomerMatchAbstractUploaderDoFn):
   def get_list_definition(self, account_config: AccountConfig, destination_metadata: List[str]) -> Dict[str, Any]:
     list_name = destination_metadata[0]
+    # Defines the list's lifespan to unlimited
+    life_span = 10000
+
+    # Overwrites lifespan value if any
+    if len(destination_metadata) >=6 and destination_metadata[5]:
+        life_span = destination_metadata[5]
+
     return {
       'membership_status': 'OPEN',
       'name': list_name,
       'description': 'List created automatically by Megalista',
-      'membership_life_span': 10000,
+      'membership_life_span': life_span,
       'crm_based_user_list': {
         'upload_key_type': 'CONTACT_INFO', #CONTACT_INFO, CRM_ID, MOBILE_ADVERTISING_ID
         'data_source_type': 'FIRST_PARTY',

--- a/megalista_dataflow/uploaders/google_ads/customer_match/mobile_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/customer_match/mobile_uploader.py
@@ -27,16 +27,22 @@ class GoogleAdsCustomerMatchMobileUploaderDoFn(GoogleAdsCustomerMatchAbstractUpl
   def get_list_definition(self, account_config: AccountConfig, destination_metadata: List[str]) -> Dict[str, Any]:
     list_name = destination_metadata[0]    
     app_id = account_config.app_id
+    # Defines the list's lifespan to unlimited
+    life_span = 10000
     
     #overwrite app_id from default to custom
     if len(destination_metadata) >=4 and len(destination_metadata[3]) > 0:
         app_id = destination_metadata[3]
 
+    # Overwrites lifespan value if any
+    if len(destination_metadata) >=6 and destination_metadata[5]:
+        life_span = destination_metadata[5]    
+
     return {
       'membership_status': 'OPEN',
       'name': list_name,
       'description': 'List created automatically by Megalista',
-      'membership_life_span': 10000,
+      'membership_life_span': life_span,
       'crm_based_user_list': {
         'upload_key_type': 'MOBILE_ADVERTISING_ID', #CONTACT_INFO, CRM_ID, MOBILE_ADVERTISING_ID
         'data_source_type': 'FIRST_PARTY',

--- a/megalista_dataflow/uploaders/google_ads/customer_match/user_id_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/customer_match/user_id_uploader.py
@@ -26,11 +26,18 @@ class GoogleAdsCustomerMatchUserIdUploaderDoFn(
       account_config: AccountConfig,
       destination_metadata: List[str]) -> Dict[str, Any]:
     list_name = destination_metadata[0]
+    # Defines the list's lifespan to unlimited
+    life_span = 10000
+    
+    # Overwrites lifespan value if any
+    if len(destination_metadata) >=6 and destination_metadata[5]:
+        life_span = destination_metadata[5] 
+
     return {
       'membership_status': 'OPEN',
       'name': list_name,
       'description': 'List created automatically by Megalista',
-      'membership_life_span': 10000,
+      'membership_life_span': life_span,
       'crm_based_user_list': {
         'upload_key_type': 'CRM_ID',
         'data_source_type': 'FIRST_PARTY',


### PR DESCRIPTION
This pull request limits the Customer Match's REPLACE keyword to send remove_all only at the first iteration, avoiding successive remove_all for every operation (batch). 

In addition, this PR also allows the user to limit the Customer Match membership lifespan through metadata values.