### PR TITLE
[GA4 MP] timestamp_micros should be sent inside the events array

### DIFF
--- a/megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol_test.py
+++ b/megalista_dataflow/uploaders/google_analytics/google_analytics_4_measurement_protocol_test.py
@@ -324,7 +324,7 @@ def test_succesful_app_event_call_with_timestamp(uploader):
         }]))
 
         assert m.call_count == 1
-        assert m.last_request.json()['timestamp_micros'] == 123123123
+        assert m.last_request.json()['events'][0]['timestamp_micros'] == 123123123
 
 def test_succesful_filter_out_nulls(uploader):
     with requests_mock.Mocker() as m:


### PR DESCRIPTION
**CHANGELOG:**

* Alter timestamp_micros location within the measurement protocol payload for GA4 to inside the events array

**OBSERVATIONS** 

_Looking at the [Measurement Protocol Reference](https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#payload), it seems like timestamp_micros should be sent at the top level of the payload. However, empirically, it does not work. I performed experiments both by using Megalista's workflow and by performing individual post requests to the collection endpoint_

_Intuitively, it makes sense that it works this way as a same request could send multiple events for a given user with distinct timestamps_