### PR TITLE
Adds backticks to left join and skips no elements

### DIFF
--- a/megalista_dataflow/data_sources/big_query/big_query_data_source.py
+++ b/megalista_dataflow/data_sources/big_query/big_query_data_source.py
@@ -86,11 +86,11 @@ class BigQueryDataSource(BaseDataSource):
             template = None
             if self._transactional_type == TransactionalType.UUID:
                 template = "SELECT $query_cols FROM `$table_name` AS data \
-                                LEFT JOIN $uploaded_table_name AS uploaded USING(uuid) \
+                                LEFT JOIN `$uploaded_table_name` AS uploaded USING(uuid) \
                                 WHERE uploaded.uuid IS NULL;"
             elif self._transactional_type == TransactionalType.GCLID_TIME:
                 template = "SELECT $query_cols FROM `$table_name` AS data \
-                                LEFT JOIN $uploaded_table_name AS uploaded USING(gclid, time) \
+                                LEFT JOIN `$uploaded_table_name` AS uploaded USING(gclid, time) \
                                 WHERE uploaded.gclid IS NULL;"
             else:
                 raise Exception(f'Unrecognized TransactionalType: {self._transactional_type}. Source="{self._source_name}". Destination="{self._destination_name}"')

--- a/megalista_dataflow/uploaders/google_analytics/google_analytics_data_import_eraser_test.py
+++ b/megalista_dataflow/uploaders/google_analytics/google_analytics_data_import_eraser_test.py
@@ -52,7 +52,7 @@ def test_analytics_has_not_data_sources(mocker, eraser, caplog, error_notifier):
                           Source('orig1', SourceType.BIG_QUERY, ['dt1', 'buyers']),
                           Destination('dest1', DestinationType.GA_DATA_IMPORT, ['web_property', 'data_import_name']))
     # Act
-    eraser.process(Batch(execution, []))
+    eraser.process(Batch(execution, ['']))
 
     eraser.finish_bundle()
 
@@ -75,7 +75,7 @@ def test_data_source_not_found(mocker, eraser, caplog, error_notifier):
                           Source('orig1', SourceType.BIG_QUERY, ['dt1', 'buyers']),
                           Destination('dest1', DestinationType.GA_DATA_IMPORT, ['web_property', 'data_import_name']))
 
-    eraser.process(Batch(execution, []))
+    eraser.process(Batch(execution, ['']))
 
     # Act
     eraser.finish_bundle()
@@ -107,7 +107,7 @@ def test_no_files_found(mocker, eraser):
     service.management().uploads().deleteUploadData.side_effect = delete_call_mock
 
     # Act
-    eraser.process(Batch(execution, []))
+    eraser.process(Batch(execution, ['']))
 
     # Called once
     delete_call_mock.assert_not_called()
@@ -136,7 +136,7 @@ def test_files_deleted_with_success(mocker, eraser):
     service.management().uploads().deleteUploadData.side_effect = delete_call_mock
 
     # Act
-    eraser.process(Batch(execution, []))
+    eraser.process(Batch(execution, ['']))
 
     # Called once
     delete_call_mock.assert_called_once()

--- a/megalista_dataflow/uploaders/google_analytics/google_analytics_user_list_uploader_test.py
+++ b/megalista_dataflow/uploaders/google_analytics/google_analytics_user_list_uploader_test.py
@@ -54,7 +54,7 @@ def test_list_already_exists(mocker, uploader):
         Destination('dest1', DestinationType.GA_USER_LIST_UPLOAD,
                     ['a', 'b', 'c', 'list', 'd', 'e']))
 
-    uploader.process(Batch(execution, []))
+    uploader.process(Batch(execution, ['']))
 
     uploader._get_analytics_service().management().remarketingAudience(
     ).insert.assert_not_called()
@@ -79,7 +79,7 @@ def test_list_creation_not_mcc(mocker, uploader):
         Destination(
             'dest1', DestinationType.GA_USER_LIST_UPLOAD,
             ['web_property', 'view', 'c', 'list', 'd', 'buyers_custom_dim']))
-    uploader.process(Batch(execution, []))
+    uploader.process(Batch(execution, ['']))
 
     service.management().remarketingAudience().insert.assert_any_call(
         accountId=ga_account_id,
@@ -126,7 +126,7 @@ def test_list_creation_mcc(mocker, uploader):
         Destination(
             'dest1', DestinationType.GA_USER_LIST_UPLOAD,
             ['web_property', 'view', 'c', 'list', 'd', 'buyers_custom_dim']))
-    uploader.process(Batch(execution, []))
+    uploader.process(Batch(execution, ['']))
 
     service.management().remarketingAudience().insert.assert_any_call(
         accountId=ga_account_id,
@@ -169,7 +169,7 @@ def test_avoid_list_creation_when_name_blank(mocker, uploader):
         Destination('dest1', DestinationType.GA_USER_LIST_UPLOAD,
                     ['web_property', 'view', 'c', '', 'd', 'buyers_custom_dim']))
 
-    uploader.process(Batch(execution, []))
+    uploader.process(Batch(execution, ['']))
 
     service.management().remarketingAudience().insert.assert_not_called()
 

--- a/megalista_dataflow/uploaders/utils.py
+++ b/megalista_dataflow/uploaders/utils.py
@@ -71,7 +71,7 @@ def safe_process(logger):
         def inner(*args, **kwargs):
             self_ = args[0]
             batch = args[1]
-            if not batch:
+            if not batch or not batch.elements:
                 logger.info('Skipping upload, received no elements.')
                 return
             logger.info(f'Uploading {len(batch.elements)} rows...')


### PR DESCRIPTION
This PR fixes the following bugs:
 - when the dataset name is a number, the bq api throws an error - added backticks to the query
 - when the batch to be processed is empty (no elements), an error is thrown for passing an empty operations element e.g.  - added a checker