### PR TITLE
Changing partial failure to warning

### DIFF
--- a/megalista_dataflow/uploaders/utils.py
+++ b/megalista_dataflow/uploaders/utils.py
@@ -122,7 +122,7 @@ def print_partial_error_messages(logger_name, action, response) -> Optional[str]
     partial_failure = getattr(response, 'partial_failure_error', None)
     if partial_failure is not None and partial_failure.message != '':
         error_message = f'Error on {action}: {partial_failure.message}.'
-        logging.getLogger(logger_name).error(error_message)
+        logging.getLogger(logger_name).warning(error_message)
     results = getattr(response, 'results', [])
     for result in results:
         gclid = getattr(result, 'gclid', None)


### PR DESCRIPTION
Changing partial failure messages from errors to warning to avoid job flag as unsuccessful 