### PR TITLE
Add support to allow an ordinal value to be supplied with CM360

### DIFF
--- a/megalista_dataflow/data_sources/data_schemas.py
+++ b/megalista_dataflow/data_sources/data_schemas.py
@@ -38,7 +38,8 @@ _dtypes: Dict[str, Dict[str, Any]] = {
             {'name': 'customVariables.type',
                 'required': False, 'data_type': 'string'},
             {'name': 'customVariables.value',
-                'required': False, 'data_type': 'string'}
+                'required': False, 'data_type': 'string'},
+            {'name': 'ordinal', 'required': False, 'data_type': 'string'}
         ],
         'groups': [
             ['gclid', 'mobileDeviceId', 'encryptedUserId', 'matchId', 'dclid']

--- a/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader.py
+++ b/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader.py
@@ -95,7 +95,6 @@ class CampaignManagerConversionUploaderDoFn(MegalistaUploader):
       to_upload = {
           'floodlightActivityId': floodlight_activity_id,
           'floodlightConfigurationId': floodlight_configuration_id,
-          'ordinal': math.floor(timestamp * 10e5),
           'timestampMicros': math.floor(timestamp * 10e5)
       }
 
@@ -116,6 +115,12 @@ class CampaignManagerConversionUploaderDoFn(MegalistaUploader):
         to_upload['quantity'] = conversion['quantity']
       else:
         to_upload['quantity'] = 1
+      
+      if 'ordinal' in conversion:
+        to_upload['ordinal'] = conversion['ordinal']
+      else:
+        to_upload['ordinal'] = str(math.floor(timestamp * 10e5))
+
       if 'customVariables' in conversion:
         custom_variables = []
         for r in conversion['customVariables']:

--- a/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader_test.py
+++ b/megalista_dataflow/uploaders/campaign_manager/campaign_manager_conversion_uploader_test.py
@@ -92,14 +92,62 @@ def test_conversion_upload(mocker, uploader):
             'gclid': '123',
             'floodlightActivityId': floodlight_activity_id,
             'floodlightConfigurationId': floodlight_configuration_id,
-            'ordinal': math.floor(current_time * 10e5),
+            'ordinal': str(math.floor(current_time * 10e5)),
             'timestampMicros': timestamp_micros,
             'quantity': 1
         }, {
             'gclid': '456',
             'floodlightActivityId': floodlight_activity_id,
             'floodlightConfigurationId': floodlight_configuration_id,
-            'ordinal': math.floor(current_time * 10e5),
+            'ordinal': str(math.floor(current_time * 10e5)),
+            'timestampMicros': math.floor(current_time * 10e5),
+            'quantity': 1
+        }],
+    }
+
+    uploader._get_dcm_service().conversions().batchinsert.assert_any_call(
+        profileId=_dcm_profile_id, body=expected_body)
+    
+def test_conversion_upload_with_ordinal(mocker, uploader):
+    mocker.patch.object(uploader, '_get_dcm_service')
+
+    floodlight_activity_id = 'floodlight_activity_id'
+    floodlight_configuration_id = 'floodlight_configuration_id'
+
+    source = Source('orig1', SourceType.BIG_QUERY, ('dt1', 'buyers'))
+    destination = Destination(
+        'dest1',
+        DestinationType.CM_OFFLINE_CONVERSION,
+        (floodlight_activity_id, floodlight_configuration_id))
+
+    execution = Execution(_account_config, source, destination)
+
+    current_time = time.time()
+
+    uploader._do_process(Batch(execution, [{
+        'gclid': '123',
+        'timestamp': '2021-11-30T12:00:00.000',
+        'ordinal': '0927252-8'
+    }, {
+        'gclid': '456'
+    }]), current_time)
+
+    # convert 2021-11-30T12:00:00.000 to timestampMicros
+    timestamp_micros = math.floor(datetime.strptime('2021-11-30T12:00:00.000', '%Y-%m-%dT%H:%M:%S.%f').timestamp() * 10e5)
+
+    expected_body = {
+        'conversions': [{
+            'gclid': '123',
+            'floodlightActivityId': floodlight_activity_id,
+            'floodlightConfigurationId': floodlight_configuration_id,
+            'ordinal': '0927252-8',
+            'timestampMicros': timestamp_micros,
+            'quantity': 1
+        }, {
+            'gclid': '456',
+            'floodlightActivityId': floodlight_activity_id,
+            'floodlightConfigurationId': floodlight_configuration_id,
+            'ordinal': str(math.floor(current_time * 10e5)),
             'timestampMicros': math.floor(current_time * 10e5),
             'quantity': 1
         }],
@@ -136,14 +184,14 @@ def test_conversion_upload_with_quantity(mocker, uploader):
             'gclid': '123',
             'floodlightActivityId': floodlight_activity_id,
             'floodlightConfigurationId': floodlight_configuration_id,
-            'ordinal': math.floor(current_time * 10e5),
+            'ordinal': str(math.floor(current_time * 10e5)),
             'timestampMicros': timestamp_micros,
             'quantity': 50
         }, {
             'gclid': '456',
             'floodlightActivityId': floodlight_activity_id,
             'floodlightConfigurationId': floodlight_configuration_id,
-            'ordinal': math.floor(current_time * 10e5),
+            'ordinal': str(math.floor(current_time * 10e5)),
             'timestampMicros': math.floor(current_time * 10e5),
             'quantity': 200
         }],
@@ -176,7 +224,7 @@ def test_conversion_upload_match_id(mocker, uploader):
             'matchId': 'abc',
             'floodlightActivityId': floodlight_activity_id,
             'floodlightConfigurationId': floodlight_configuration_id,
-            'ordinal': math.floor(current_time * 10e5),
+            'ordinal': str(math.floor(current_time * 10e5)),
             'timestampMicros': math.floor(current_time * 10e5),
             'quantity': 1
         }],
@@ -221,7 +269,7 @@ def test_conversion_upload_match_id_additional_fields(mocker, uploader):
             'matchId': 'abc',
             'floodlightActivityId': floodlight_activity_id,
             'floodlightConfigurationId': floodlight_configuration_id,
-            'ordinal': math.floor(current_time * 10e5),
+            'ordinal': str(math.floor(current_time * 10e5)),
             'timestampMicros': math.floor(current_time * 10e5),
             'value': 1,
             'quantity': 2,
@@ -270,7 +318,7 @@ def test_conversion_upload_decimal_value(mocker, uploader):
             'gclid': 'abc',
             'floodlightActivityId': floodlight_activity_id,
             'floodlightConfigurationId': floodlight_configuration_id,
-            'ordinal': math.floor(current_time * 10e5),
+            'ordinal': str(math.floor(current_time * 10e5)),
             'timestampMicros': math.floor(current_time * 10e5),
             'value': 540.12,
             'quantity': 1


### PR DESCRIPTION
This PR adds support to supply a distinct ordinal per conversions (to support leveraging CM360's in-built deduplication logic - useful in the event of multiple parallel file-based uploads)

Adds a test covering this scenario and casts the ordinal type to string (as it is explicitly a string in the [documentation](https://developers.google.com/doubleclick-advertisers/rest/v4/Conversion#:~:text=a%20required%20field.-,ordinal,-string))