### PR TITLE
Ads conversions consent support

### DIFF
--- a/megalista_dataflow/data_sources/data_schemas.py
+++ b/megalista_dataflow/data_sources/data_schemas.py
@@ -51,7 +51,9 @@ _dtypes: Dict[str, Dict[str, Any]] = {
             {'name': 'time', 'required': True, 'data_type': 'string'},
             {'name': 'amount', 'required': True, 'data_type': 'string'},
             {'name': 'external_attribution_credit', 'required': False, 'data_type': 'string'},
-            {'name': 'external_attribution_model', 'required': False, 'data_type': 'string'}
+            {'name': 'external_attribution_model', 'required': False, 'data_type': 'string'},
+            {'name': 'consent_ad_user_data', 'required': False, 'data_type': 'string'},
+            {'name': 'consent_ad_personalization', 'required': False, 'data_type': 'string'}
         ],
         'groups': []
     },
@@ -78,7 +80,11 @@ _dtypes: Dict[str, Dict[str, Any]] = {
             {'name': 'time', 'required': True, 'data_type': 'string'},
             {'name': 'amount', 'required': True, 'data_type': 'string'},
             {'name': 'email', 'required': False, 'data_type': 'string'},
-            {'name': 'phone', 'required': False, 'data_type': 'string'}
+            {'name': 'phone', 'required': False, 'data_type': 'string'},
+            {'name': 'external_attribution_credit', 'required': False, 'data_type': 'string'},
+            {'name': 'external_attribution_model', 'required': False, 'data_type': 'string'},
+            {'name': 'consent_ad_user_data', 'required': False, 'data_type': 'string'},
+            {'name': 'consent_ad_personalization', 'required': False, 'data_type': 'string'}
         ],
         'groups': [
             ['email', 'phone']
@@ -89,7 +95,9 @@ _dtypes: Dict[str, Dict[str, Any]] = {
             {'name': 'caller_id', 'required': True, 'data_type': 'string'},
             {'name': 'call_time', 'required': True, 'data_type': 'string'},
             {'name': 'time', 'required': True, 'data_type': 'string'},
-            {'name': 'amount', 'required': True, 'data_type': 'string'}
+            {'name': 'amount', 'required': True, 'data_type': 'string'},
+            {'name': 'consent_ad_user_data', 'required': False, 'data_type': 'string'},
+            {'name': 'consent_ad_personalization', 'required': False, 'data_type': 'string'}
         ],
         'groups': []
     },

--- a/megalista_dataflow/uploaders/google_ads/conversions/google_ads_enhanced_conversions_leads_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/conversions/google_ads_enhanced_conversions_leads_uploader.py
@@ -131,8 +131,8 @@ class GoogleAdsECLeadsUploaderDoFn(MegalistaUploader):
             #adds consent data if provided
             if 'consent_ad_user_data' in row and 'consent_ad_personalization' in row:
                 conversion['consent'] = {
-                'ad_user_data': row['ad_user_data'],
-                'ad_personalization': row['ad_personalization']
+                'ad_user_data': row['consent_ad_user_data'],
+                'ad_personalization': row['consent_ad_personalization']
                 }
             conversions.append(conversion)
 

--- a/megalista_dataflow/uploaders/google_ads/conversions/google_ads_enhanced_conversions_leads_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/conversions/google_ads_enhanced_conversions_leads_uploader.py
@@ -113,14 +113,28 @@ class GoogleAdsECLeadsUploaderDoFn(MegalistaUploader):
         return [batch]
 
     def _do_upload(self, oc_service, execution, conversion_resource_name, customer_id, rows):
-        logging.getLogger(_DEFAULT_LOGGER).info(
-            f'Uploading {len(rows)} offline conversions on {conversion_resource_name} to Google Ads.')
-        conversions = [{
-            'conversion_action': conversion_resource_name,
-            'conversion_date_time': utils.format_date(conversion['time']),
-            'conversion_value': float(str(conversion['amount'])),
-            'user_identifiers': [{k: v} for (k, v) in conversion.items() if k in ('hashed_email', 'hashed_phone_number')]
-        } for conversion in rows]
+        logging.getLogger(_DEFAULT_LOGGER).info(f'Uploading {len(rows)} offline conversions on {conversion_resource_name} to Google Ads.')
+        conversions = []
+        for row in rows:
+            conversion= {
+                'conversion_action': conversion_resource_name,
+                'conversion_date_time': utils.format_date(row['time']),
+                'conversion_value': float(str(row['amount'])),
+                'user_identifiers': [{k: v} for (k, v) in conversion.items() if k in ('hashed_email', 'hashed_phone_number')]
+            }
+            #adds external attribution data if provided
+            if 'external_attribution_credit' in row and 'external_attribution_model' in row:
+                conversion['external_attribution_data'] = {
+                'external_attribution_credit': float(str(row['external_attribution_credit'])),
+                'external_attribution_model': row['external_attribution_model']
+                }
+            #adds consent data if provided
+            if 'consent_ad_user_data' in row and 'consent_ad_personalization' in row:
+                conversion['consent'] = {
+                'ad_user_data': row['ad_user_data'],
+                'ad_personalization': row['ad_personalization']
+                }
+            conversions.append(conversion)
 
         upload_data = {
             'customer_id': customer_id,
@@ -163,13 +177,13 @@ class GoogleAdsECLeadsUploaderDoFn(MegalistaUploader):
                         f'Google Ads for account {customer_id} has not been set up for Enhanced Conversions for Leads, check https://developers.google.com/google-ads/api/docs/conversions/upload-identifiers'
                     )
 
-    def _get_results_dataframe(self, response):
-        successful_users = [
-            user for user in response.results if user.ListFields()]
-        logging.getLogger(_DEFAULT_LOGGER).info(
-            f'Sucessfully uploaded {len(successful_users)} conversions')
+    # def _get_results_dataframe(self, response):
+    #     successful_users = [
+    #         user for user in response.results if user.ListFields()]
+    #     logging.getLogger(_DEFAULT_LOGGER).info(
+    #         f'Sucessfully uploaded {len(successful_users)} conversions')
 
-        sucess_df = pd.DataFrame(columns=['conversion_action',
-                                          'conversion_date_time',
-                                          'hashed_email',
-                                          'hashed_phone_number'])
+    #     sucess_df = pd.DataFrame(columns=['conversion_action',
+    #                                       'conversion_date_time',
+    #                                       'hashed_email',
+    #                                       'hashed_phone_number'])

--- a/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_calls_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_calls_uploader.py
@@ -107,8 +107,8 @@ class GoogleAdsOfflineUploaderCallsDoFn(MegalistaUploader):
       #adds consent data if provided
       if 'consent_ad_user_data' in row and 'consent_ad_personalization' in row:
         conversion['consent'] = {
-          'ad_user_data': row['ad_user_data'],
-          'ad_personalization': row['ad_personalization']
+          'ad_user_data': row['consent_ad_user_data'],
+          'ad_personalization': row['consent_ad_personalization']
         }
       conversions.append(conversion)
 

--- a/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_calls_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_calls_uploader.py
@@ -99,10 +99,10 @@ class GoogleAdsOfflineUploaderCallsDoFn(MegalistaUploader):
     for row in rows:
       conversion= {
         'conversion_action': conversion_resource_name,
-        'caller_id': conversion['caller_id'],
-        'call_start_date_time': utils.format_date(conversion['call_time']),
-        'conversion_date_time': utils.format_date(conversion['time']),
-        'conversion_value': float(str(conversion['amount']))
+        'caller_id': row['caller_id'],
+        'call_start_date_time': utils.format_date(row['call_time']),
+        'conversion_date_time': utils.format_date(row['time']),
+        'conversion_value': float(str(row['amount']))
       }
       #adds consent data if provided
       if 'consent_ad_user_data' in row and 'consent_ad_personalization' in row:

--- a/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_calls_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_calls_uploader.py
@@ -104,12 +104,6 @@ class GoogleAdsOfflineUploaderCallsDoFn(MegalistaUploader):
         'conversion_date_time': utils.format_date(conversion['time']),
         'conversion_value': float(str(conversion['amount']))
       }
-      #adds external attribution data if provided
-      if 'external_attribution_credit' in row and 'external_attribution_model' in row:
-        conversion['external_attribution_data'] = {
-          'external_attribution_credit': float(str(row['external_attribution_credit'])),
-          'external_attribution_model': row['external_attribution_model']
-        }
       #adds consent data if provided
       if 'consent_ad_user_data' in row and 'consent_ad_personalization' in row:
         conversion['consent'] = {

--- a/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_calls_uploader_test.py
+++ b/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_calls_uploader_test.py
@@ -283,6 +283,78 @@ def test_error_notification(mocker, uploader, error_notifier):
   assert error_notifier.destination_type is DestinationType.ADS_OFFLINE_CONVERSION_CALLS
   assert error_notifier.errors_sent == {execution: f'Error on uploading offline conversions (calls): {error_message}.'}
 
+def test_conversion_upload_with_consent(mocker, uploader):
+  # arrange
+  conversion_resource_name = 'user_list_resouce'
+  arrange_conversion_resource_name_api_call(mocker, uploader, conversion_resource_name)
+
+  mocker.patch.object(uploader, '_get_oc_service')
+  conversion_name = 'user_list'
+  destination = Destination(
+    'dest1', DestinationType.ADS_OFFLINE_CONVERSION_CALLS, ['user_list'])
+  source = Source('orig1', SourceType.BIG_QUERY, ['dt1', 'buyers'])
+  execution = Execution(_account_config, source, destination)
+
+  time1 = '2020-04-09T14:13:55.0005'
+  time1_result = '2020-04-09 14:13:55-03:00'
+
+  call_time1 = '2020-04-08T14:13:55.0005'
+  call_time1_result = '2020-04-08 14:13:55-03:00'
+
+  time2 = '2020-04-09T13:13:55.0005'
+  time2_result = '2020-04-09 13:13:55-03:00'
+
+  call_time2 = '2020-04-08T13:13:55.0005'
+  call_time2_result = '2020-04-08 13:13:55-03:00'
+
+  element1 = {
+    'time': time1,
+    'call_time': call_time1,
+    'amount': '123',
+    'caller_id': '+5511987654321',
+    'consent_ad_user_data': 'GRANTED',
+    'consent_ad_personalization': 'GRANTED'
+  }
+  element2 = {
+    'time': time2,
+    'call_time': call_time2,
+    'amount': '234',
+    'caller_id': '+5511987654321'
+  }
+
+  batch = Batch(execution, [element1, element2])
+
+  # act
+  uploader.process(batch)
+  uploader.finish_bundle()
+
+  uploader._get_ads_service.return_value.search_stream.assert_called_once_with(
+    customer_id='12345567890',
+    query=f"SELECT conversion_action.resource_name FROM conversion_action WHERE conversion_action.name = '{conversion_name}'"
+  )
+
+  uploader._get_oc_service.return_value.upload_call_conversions.assert_called_once_with(request={
+    'customer_id': '12345567890',
+    'partial_failure': True,
+    'validate_only': False,
+    'conversions': [{
+      'conversion_action': conversion_resource_name,
+      'call_start_date_time': call_time1_result,
+      'conversion_date_time': time1_result,
+      'conversion_value': 123,
+      'caller_id': '+5511987654321',
+      'consent': {
+        'ad_user_data': 'GRANTED',
+        'ad_personalization': 'GRANTED'
+      }
+    }, {
+      'conversion_action': conversion_resource_name,
+      'call_start_date_time': call_time2_result,
+      'conversion_date_time': time2_result,
+      'conversion_value': 234,
+      'caller_id': '+5511987654321'
+    }]
+  })
 
 # def test_conversion_upload_and_error_notification(mocker, uploader, error_notifier):
 #   """

--- a/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_uploader.py
@@ -114,10 +114,17 @@ class GoogleAdsOfflineUploaderDoFn(MegalistaUploader):
         'conversion_value': float(str(row['amount'])),
         'gclid': row['gclid']
       }
+      #adds external attribution data if provided
       if 'external_attribution_credit' in row and 'external_attribution_model' in row:
         conversion['external_attribution_data'] = {
           'external_attribution_credit': float(str(row['external_attribution_credit'])),
           'external_attribution_model': row['external_attribution_model']
+        }
+      #adds consent data if provided
+      if 'consent_ad_user_data' in row and 'consent_ad_personalization' in row:
+        conversion['consent'] = {
+          'ad_user_data': row['ad_user_data'],
+          'ad_personalization': row['ad_personalization']
         }
       conversions.append(conversion)
 

--- a/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_uploader.py
+++ b/megalista_dataflow/uploaders/google_ads/conversions/google_ads_offline_conversions_uploader.py
@@ -123,8 +123,8 @@ class GoogleAdsOfflineUploaderDoFn(MegalistaUploader):
       #adds consent data if provided
       if 'consent_ad_user_data' in row and 'consent_ad_personalization' in row:
         conversion['consent'] = {
-          'ad_user_data': row['ad_user_data'],
-          'ad_personalization': row['ad_personalization']
+          'ad_user_data': row['consent_ad_user_data'],
+          'ad_personalization': row['consent_ad_personalization']
         }
       conversions.append(conversion)
 


### PR DESCRIPTION
Adding support to send consent data in Google Ads Conversions:
Click, EC4L, CallConversions
Also includes external attribution for EC4L